### PR TITLE
Fix isolation indicator stuck on pending

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,9 +7,12 @@ const logBox = $("#log");
 const log = (...args) => { logBox.textContent += args.join(' ') + "\n"; logBox.scrollTop = logBox.scrollHeight; };
 
 // --- 显示跨源隔离状态
-const isoPill = $("#iso");
-const setIso = () => isoPill.textContent = window.crossOriginIsolated ? "✅ 已隔离 (SharedArrayBuffer 可用)" : "⚠️ 未隔离 (将尝试通过 SW 启用)";
-setIso();
+const ensureIsoIndicator = () => {
+  if (typeof window.__updateIsolationStatus === 'function') {
+    window.__updateIsolationStatus();
+  }
+};
+ensureIsoIndicator();
 
 const ffmpeg = new FFmpeg();
 ffmpeg.on('log', ({ message }) => log(message));

--- a/coi-serviceworker.js
+++ b/coi-serviceworker.js
@@ -1,7 +1,15 @@
 // coi-serviceworker.js
 // 基于常见实现：补 COOP/COEP 头以启用 SharedArrayBuffer
 self.addEventListener('install', () => self.skipWaiting());
-self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));
+self.addEventListener('activate', (event) => {
+  event.waitUntil((async () => {
+    await self.clients.claim();
+    const clients = await self.clients.matchAll({ type: 'window' });
+    for (const client of clients) {
+      client.postMessage({ type: 'coi-ready' });
+    }
+  })());
+});
 
 self.addEventListener('fetch', (event) => {
   const r = event.request;

--- a/index.html
+++ b/index.html
@@ -20,6 +20,56 @@
     <span id="iso" class="pill">检测中...</span>
   </p>
 
+  <script>
+    (() => {
+      const isoPill = document.querySelector('#iso');
+      if (!isoPill) return;
+
+      const setIsoText = () => {
+        isoPill.textContent = window.crossOriginIsolated
+          ? '✅ 已隔离 (SharedArrayBuffer 可用)'
+          : '⚠️ 未隔离 (将尝试通过 SW 启用)';
+      };
+
+      let pollTimer = null;
+      const updateWithRetry = () => {
+        setIsoText();
+        if (window.crossOriginIsolated && pollTimer) {
+          clearInterval(pollTimer);
+          pollTimer = null;
+        }
+      };
+
+      const ensureIsolationStatus = () => {
+        updateWithRetry();
+        if (!window.crossOriginIsolated && pollTimer === null) {
+          let attempts = 0;
+          pollTimer = setInterval(() => {
+            attempts += 1;
+            updateWithRetry();
+            if (window.crossOriginIsolated || attempts >= 20) {
+              clearInterval(pollTimer);
+              pollTimer = null;
+            }
+          }, 500);
+        }
+      };
+
+      ensureIsolationStatus();
+
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.addEventListener('controllerchange', ensureIsolationStatus);
+        navigator.serviceWorker.addEventListener('message', (event) => {
+          if (event.data && event.data.type === 'coi-ready') {
+            ensureIsolationStatus();
+          }
+        });
+      }
+
+      window.__updateIsolationStatus = ensureIsolationStatus;
+    })();
+  </script>
+
   <p>
     <input id="file" type="file" accept="audio/*,video/*" />
     <button id="btn-load">加载 FFmpeg 核心</button>


### PR DESCRIPTION
## Summary
- add an inline isolation status helper that polls and listens for service worker updates so the UI leaves the pending state
- notify controlled pages from the service worker once it activates
- reuse the shared helper from the main module when it loads

## Testing
- ⚠️ Not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d26c5aca2c833292906ce6455ce424