### PR TITLE
Add web-based video-to-audio extractor

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,259 @@
+import { FFmpeg } from "https://unpkg.com/@ffmpeg/ffmpeg@0.12.7/dist/esm/classes.js";
+import { fetchFile } from "https://unpkg.com/@ffmpeg/util@0.12.1/dist/esm/index.js";
+
+const dropZone = document.getElementById("drop-zone");
+const fileInput = document.getElementById("file-input");
+const convertBtn = document.getElementById("convert-btn");
+const fileInfo = document.getElementById("file-info");
+const statusEl = document.getElementById("status");
+const progressBar = document.getElementById("progress-bar");
+const logOutput = document.getElementById("log-output");
+const resultSection = document.getElementById("result");
+const downloadLink = document.getElementById("download-link");
+
+const ffmpeg = new FFmpeg();
+let ffmpegReady = false;
+let currentFile = null;
+let currentObjectUrl = null;
+
+const formatBytes = (bytes) => {
+  if (!Number.isFinite(bytes)) return "未知大小";
+  if (bytes === 0) return "0 B";
+  const units = ["B", "KB", "MB", "GB", "TB"];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 2)} ${units[exponent]}`;
+};
+
+const sanitizeName = (name) => name.replace(/[^\w.\-]+/g, "_");
+
+const getExtension = (filename) => {
+  const match = /\.([^.]+)$/.exec(filename || "");
+  return match ? match[1].toLowerCase() : "";
+};
+
+const guessMime = (ext) => {
+  switch (ext) {
+    case "mp4":
+    case "m4v":
+    case "m4a":
+      return "audio/mp4";
+    case "mov":
+      return "audio/quicktime";
+    case "webm":
+      return "audio/webm";
+    case "mkv":
+      return "audio/x-matroska";
+    case "mpg":
+    case "mpeg":
+    case "mp3":
+      return "audio/mpeg";
+    case "wav":
+      return "audio/wav";
+    case "flv":
+      return "audio/x-flv";
+    case "ogg":
+    case "ogv":
+    case "oga":
+      return "audio/ogg";
+    default:
+      return "audio/octet-stream";
+  }
+};
+
+const setStatus = (message) => {
+  statusEl.textContent = message;
+};
+
+const resetProgress = () => {
+  progressBar.style.width = "0%";
+};
+
+const updateProgress = (value) => {
+  const clamped = Math.max(0, Math.min(100, value));
+  progressBar.style.width = `${clamped}%`;
+};
+
+const appendLog = (message = "") => {
+  let text = "";
+  if (typeof message === "string") {
+    text = message;
+  } else if (message instanceof Error) {
+    text = message.message;
+  } else if (message && typeof message === "object" && "message" in message) {
+    text = String(message.message);
+  } else {
+    try {
+      text = JSON.stringify(message);
+    } catch (err) {
+      text = String(message);
+    }
+  }
+  logOutput.textContent += `${text}\n`;
+  logOutput.scrollTop = logOutput.scrollHeight;
+};
+
+const clearLog = () => {
+  logOutput.textContent = "";
+};
+
+const loadFFmpeg = async () => {
+  if (ffmpegReady) return;
+  setStatus("正在加载多线程 FFmpeg 核心...");
+  try {
+    await ffmpeg.load({
+      coreURL: new URL("./ffmpeg-core/ffmpeg-core.js", window.location.href).href,
+      wasmURL: new URL("./ffmpeg-core/ffmpeg-core.wasm", window.location.href).href,
+      workerURL: new URL("./ffmpeg-core/ffmpeg-core.worker.js", window.location.href).href,
+    });
+    ffmpegReady = true;
+    setStatus("FFmpeg 已就绪，可开始处理");
+  } catch (error) {
+    appendLog(error);
+    setStatus("加载 FFmpeg 失败，请刷新页面后重试");
+    throw error;
+  }
+};
+
+const selectFile = (file) => {
+  currentFile = file;
+  resultSection.hidden = true;
+  if (currentObjectUrl) {
+    URL.revokeObjectURL(currentObjectUrl);
+    currentObjectUrl = null;
+  }
+  if (file) {
+    fileInfo.textContent = `${file.name}（${formatBytes(file.size)}）`;
+    convertBtn.disabled = false;
+    setStatus("准备就绪，点击开始提取音频");
+  } else {
+    fileInfo.textContent = "尚未选择文件";
+    convertBtn.disabled = true;
+    setStatus("等待操作");
+  }
+};
+
+const prepareArgs = (inputName, outputName) => {
+  const hardwareThreads = navigator.hardwareConcurrency || 4;
+  const threads = Math.max(1, Math.min(16, hardwareThreads));
+  return [
+    "-i",
+    inputName,
+    "-vn",
+    "-acodec",
+    "copy",
+    "-threads",
+    `${threads}`,
+    outputName,
+  ];
+};
+
+const runExtraction = async () => {
+  if (!currentFile) return;
+  convertBtn.disabled = true;
+  resetProgress();
+  clearLog();
+  setStatus("初始化中...");
+
+  let ext = "m4a";
+  let safeBase = "output";
+  let inputName = "input.m4a";
+  let outputName = "output_audio.m4a";
+
+  try {
+    await loadFFmpeg();
+
+    ext = getExtension(currentFile.name) || "m4a";
+    safeBase = sanitizeName(currentFile.name.replace(/\.[^.]*$/, "")) || "output";
+    inputName = `input.${ext}`;
+    outputName = `${safeBase}_audio.${ext}`;
+
+    appendLog(`写入文件: ${inputName}`);
+    await ffmpeg.writeFile(inputName, await fetchFile(currentFile));
+
+    const args = prepareArgs(inputName, outputName);
+    appendLog(`执行命令: ffmpeg ${args.join(" ")}`);
+    setStatus("正在提取音频...");
+
+    const resultCode = await ffmpeg.exec(args);
+    if (resultCode !== 0) {
+      throw new Error(`FFmpeg 处理失败，返回码 ${resultCode}`);
+    }
+
+    setStatus("读取生成的音频...");
+    const data = await ffmpeg.readFile(outputName);
+    const blob = new Blob([data.buffer], { type: guessMime(ext) });
+    currentObjectUrl = URL.createObjectURL(blob);
+    downloadLink.href = currentObjectUrl;
+    downloadLink.download = outputName;
+    resultSection.hidden = false;
+    setStatus("提取完成，点击下载音频");
+    updateProgress(100);
+  } catch (error) {
+    console.error(error);
+    appendLog(`错误: ${error.message || error}`);
+    setStatus("提取失败，请重试或更换文件");
+  } finally {
+    try {
+      await ffmpeg.deleteFile?.(inputName);
+      await ffmpeg.deleteFile?.(outputName);
+    } catch (cleanupError) {
+      if (cleanupError) {
+        appendLog(`清理缓存失败: ${cleanupError.message || cleanupError}`);
+      }
+    }
+    convertBtn.disabled = !currentFile;
+  }
+};
+
+ffmpeg.on("log", ({ type, message }) => {
+  if (!message) return;
+  appendLog(`[${type ?? "log"}] ${message}`);
+});
+
+ffmpeg.on("progress", ({ progress, time }) => {
+  if (typeof progress === "number" && Number.isFinite(progress)) {
+    const percent = Math.min(100, Math.max(0, progress * 100));
+    updateProgress(percent);
+    const timeText = typeof time === "number" && Number.isFinite(time)
+      ? `（耗时 ${time.toFixed(1)}s）`
+      : "";
+    setStatus(`提取中：${percent.toFixed(0)}%${timeText}`);
+  }
+});
+
+convertBtn.addEventListener("click", () => {
+  if (!currentFile) return;
+  runExtraction();
+});
+
+fileInput.addEventListener("change", (event) => {
+  const [file] = event.target.files || [];
+  selectFile(file || null);
+});
+
+dropZone.addEventListener("dragover", (event) => {
+  event.preventDefault();
+  dropZone.classList.add("dragover");
+});
+
+dropZone.addEventListener("dragleave", () => {
+  dropZone.classList.remove("dragover");
+});
+
+dropZone.addEventListener("drop", (event) => {
+  event.preventDefault();
+  dropZone.classList.remove("dragover");
+  const file = event.dataTransfer?.files?.[0];
+  if (file) {
+    fileInput.files = event.dataTransfer.files;
+    selectFile(file);
+  }
+});
+
+window.addEventListener("beforeunload", () => {
+  if (currentObjectUrl) {
+    URL.revokeObjectURL(currentObjectUrl);
+  }
+});
+
+setStatus("等待操作");

--- a/index.html
+++ b/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>视频转音频提取器</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <h1>视频音频提取器</h1>
+      <p>上传本地视频，在线提取原始音频编码并立即下载。完全在浏览器中运行，适用于 Windows、iOS 与 Android。</p>
+    </header>
+    <main>
+      <section class="uploader" id="drop-zone">
+        <input type="file" id="file-input" accept="video/*" />
+        <label for="file-input" id="file-label">
+          <span class="label-main">拖放或点击选择视频文件</span>
+          <span class="label-sub">支持主流视频格式，处理过程在本地完成</span>
+        </label>
+      </section>
+      <section class="controls">
+        <div class="file-info" id="file-info">尚未选择文件</div>
+        <button id="convert-btn" disabled>开始提取音频</button>
+      </section>
+      <section class="progress" aria-live="polite">
+        <div class="progress-bar" id="progress-bar"></div>
+        <div class="status" id="status">等待操作</div>
+      </section>
+      <section class="result" id="result" hidden>
+        <h2>提取完成</h2>
+        <a id="download-link" download>点击下载音频</a>
+      </section>
+      <section class="log" aria-live="polite">
+        <h2>处理日志</h2>
+        <pre id="log-output"></pre>
+      </section>
+    </main>
+    <footer>
+      <p>所有转换均在浏览器中完成，不会上传到服务器。</p>
+    </footer>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,202 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
+  background: linear-gradient(180deg, #101928 0%, #05070c 100%);
+  color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+header,
+footer {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  background: rgba(15, 23, 42, 0.8);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+footer {
+  margin-top: auto;
+  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: none;
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+main {
+  flex: 1;
+  padding: 2rem 1rem 3rem;
+  max-width: 900px;
+  width: 100%;
+  margin: 0 auto;
+  display: grid;
+  gap: 1.5rem;
+}
+
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.uploader {
+  position: relative;
+  border: 2px dashed rgba(148, 163, 184, 0.4);
+  border-radius: 16px;
+  padding: 3rem 1rem;
+  text-align: center;
+  transition: border-color 0.3s ease, background 0.3s ease;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.uploader.dragover {
+  border-color: #38bdf8;
+  background: rgba(59, 130, 246, 0.15);
+}
+
+#file-input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+#file-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  pointer-events: none;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.label-main {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.label-sub {
+  font-size: 0.95rem;
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(15, 23, 42, 0.6);
+  padding: 1rem 1.25rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.file-info {
+  flex: 1;
+  min-width: 200px;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+button {
+  appearance: none;
+  border: none;
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  box-shadow: none;
+}
+
+button:not(:disabled):hover {
+  transform: translateY(-2px);
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.35);
+}
+
+.progress {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem 1.25rem;
+}
+
+.progress-bar {
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, #22d3ee, #0ea5e9);
+  width: 0%;
+  transition: width 0.2s ease;
+}
+
+.status {
+  margin-top: 0.75rem;
+  font-size: 0.95rem;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.result,
+.log {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1.25rem 1.5rem;
+}
+
+.result a {
+  display: inline-block;
+  margin-top: 0.5rem;
+  color: #38bdf8;
+  font-weight: 600;
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.result a:hover {
+  color: #7dd3fc;
+}
+
+.log pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 240px;
+  overflow-y: auto;
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.9);
+  background: rgba(15, 23, 42, 0.45);
+  padding: 1rem;
+  border-radius: 10px;
+}
+
+@media (max-width: 600px) {
+  main {
+    padding: 1.5rem 1rem 2rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  button {
+    width: 100%;
+  }
+}


### PR DESCRIPTION
## Summary
- add a static single-page app for uploading videos and extracting their original audio tracks entirely in the browser
- integrate multi-threaded ffmpeg.wasm with local core assets and detailed progress/log display
- style the interface for desktop and mobile use with drag-and-drop support and direct download links

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d272de5b088332bfa75ea0bcd78764