### PR TITLE
Add audio/video app picker and automatic light theme

### DIFF
--- a/extractor.html
+++ b/extractor.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="zh-Hans">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>批量视频音频提取器 · 音视频操作</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header>
+      <nav class="top-nav" aria-label="页面导航">
+        <a class="back-link" href="index.html">← 返回应用选择</a>
+      </nav>
+      <h1>批量视频音频提取器</h1>
+      <p>
+        上传任意数量的视频或压缩文件，自动提取其中所有视频的原始音频编码并提供下载。所有处理均在浏览器本地完成，适用于
+        Windows、iOS 与 Android。
+      </p>
+    </header>
+    <main>
+      <section class="uploader" id="drop-zone">
+        <input
+          type="file"
+          id="file-input"
+          accept="video/*,.zip,application/zip"
+          multiple
+        />
+        <label for="file-input" id="file-label">
+          <span class="label-main">拖放或点击选择文件</span>
+          <span class="label-sub">支持多视频文件与 ZIP 压缩包，处理过程在本地完成</span>
+        </label>
+      </section>
+      <section class="controls">
+        <div class="file-info" id="file-info">尚未选择文件</div>
+        <button id="convert-btn" disabled>开始批量提取音频</button>
+      </section>
+      <section class="progress" aria-live="polite">
+        <div class="progress-bar" id="progress-bar"></div>
+        <div class="status" id="status">等待操作</div>
+      </section>
+      <section class="result" id="result" hidden>
+        <h2>提取完成</h2>
+        <p id="result-summary"></p>
+        <div id="download-list" class="download-list"></div>
+      </section>
+      <section class="log" aria-live="polite">
+        <h2>处理日志</h2>
+        <pre id="log-output"></pre>
+      </section>
+    </main>
+    <footer>
+      <p>所有转换均在浏览器中完成，不会上传到服务器。</p>
+    </footer>
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,48 +3,54 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>批量视频音频提取器</title>
+    <title>音视频操作工具集</title>
     <link rel="stylesheet" href="styles.css" />
   </head>
-  <body>
+  <body class="app-selection">
     <header>
-      <h1>批量视频音频提取器</h1>
-      <p>上传任意数量的视频或压缩文件，自动提取其中所有视频的原始音频编码并提供下载。所有处理均在浏览器本地完成，适用于 Windows、iOS 与 Android。</p>
+      <h1>音视频操作</h1>
+      <p>
+        在浏览器中即可完成常用的音视频工具操作，所有处理均在本地执行，保证隐私安全。
+      </p>
     </header>
     <main>
-      <section class="uploader" id="drop-zone">
-        <input
-          type="file"
-          id="file-input"
-          accept="video/*,.zip,application/zip"
-          multiple
-        />
-        <label for="file-input" id="file-label">
-          <span class="label-main">拖放或点击选择文件</span>
-          <span class="label-sub">支持多视频文件与 ZIP 压缩包，处理过程在本地完成</span>
-        </label>
+      <section class="intro">
+        <p>
+          选择一个工具开始使用。所有应用均无需安装软件，也无需上传文件到服务器。
+        </p>
       </section>
-      <section class="controls">
-        <div class="file-info" id="file-info">尚未选择文件</div>
-        <button id="convert-btn" disabled>开始批量提取音频</button>
-      </section>
-      <section class="progress" aria-live="polite">
-        <div class="progress-bar" id="progress-bar"></div>
-        <div class="status" id="status">等待操作</div>
-      </section>
-      <section class="result" id="result" hidden>
-        <h2>提取完成</h2>
-        <p id="result-summary"></p>
-        <div id="download-list" class="download-list"></div>
-      </section>
-      <section class="log" aria-live="polite">
-        <h2>处理日志</h2>
-        <pre id="log-output"></pre>
+      <section class="app-grid" aria-label="可用应用列表">
+        <article class="app-card">
+          <div class="app-card-body">
+            <header class="app-card-header">
+              <span class="app-card-tag">热门</span>
+              <h2>批量视频音频提取器</h2>
+            </header>
+            <p>
+              支持批量选择视频或 ZIP 压缩包，自动提取其中所有视频的原始音频编码并提供下载。
+            </p>
+            <ul>
+              <li>支持绝大多数常见视频格式</li>
+              <li>可直接处理压缩包中的视频</li>
+              <li>所有转换均在本地完成，保护隐私</li>
+            </ul>
+          </div>
+          <a class="app-card-action" href="extractor.html">进入应用</a>
+        </article>
+        <article class="app-card app-card--disabled" aria-disabled="true">
+          <div class="app-card-body">
+            <header class="app-card-header">
+              <span class="app-card-tag app-card-tag--muted">即将上线</span>
+              <h2>更多工具</h2>
+            </header>
+            <p>我们正在积极构建更多音视频处理功能，敬请期待。</p>
+          </div>
+          <span class="app-card-action">敬请期待</span>
+        </article>
       </section>
     </main>
     <footer>
-      <p>所有转换均在浏览器中完成，不会上传到服务器。</p>
+      <p>音视频操作工具集 · 所有处理均在设备本地完成。</p>
     </footer>
-    <script type="module" src="app.js"></script>
   </body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -1,8 +1,44 @@
 :root {
   color-scheme: light dark;
   font-family: "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", sans-serif;
-  background: linear-gradient(180deg, #101928 0%, #05070c 100%);
-  color: #f5f7fa;
+  --background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  --header-footer-bg: rgba(255, 255, 255, 0.82);
+  --surface-bg: rgba(255, 255, 255, 0.82);
+  --surface-strong-bg: rgba(255, 255, 255, 0.9);
+  --surface-muted-bg: rgba(241, 245, 249, 0.92);
+  --border-color: rgba(148, 163, 184, 0.35);
+  --card-border: rgba(148, 163, 184, 0.28);
+  --text-primary: #0f172a;
+  --text-secondary: #334155;
+  --text-tertiary: #475569;
+  --accent-start: #2563eb;
+  --accent-end: #38bdf8;
+  --accent-hover: #60a5fa;
+  --accent-shadow: rgba(56, 189, 248, 0.35);
+  --card-hover: rgba(59, 130, 246, 0.12);
+  --tag-bg: rgba(59, 130, 246, 0.18);
+  --tag-muted-bg: rgba(148, 163, 184, 0.3);
+  --muted-text: rgba(100, 116, 139, 0.85);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --background: linear-gradient(180deg, #101928 0%, #05070c 100%);
+    --header-footer-bg: rgba(15, 23, 42, 0.8);
+    --surface-bg: rgba(15, 23, 42, 0.6);
+    --surface-strong-bg: rgba(15, 23, 42, 0.72);
+    --surface-muted-bg: rgba(30, 41, 59, 0.75);
+    --border-color: rgba(148, 163, 184, 0.2);
+    --card-border: rgba(148, 163, 184, 0.2);
+    --text-primary: #f5f7fa;
+    --text-secondary: rgba(226, 232, 240, 0.9);
+    --text-tertiary: rgba(148, 163, 184, 0.8);
+    --accent-hover: #7dd3fc;
+    --card-hover: rgba(59, 130, 246, 0.18);
+    --tag-bg: rgba(56, 189, 248, 0.2);
+    --tag-muted-bg: rgba(71, 85, 105, 0.7);
+    --muted-text: rgba(148, 163, 184, 0.85);
+  }
 }
 
 body {
@@ -11,23 +47,30 @@ body {
   display: flex;
   flex-direction: column;
   align-items: stretch;
+  background: var(--background);
+  color: var(--text-primary);
+  transition: background 0.4s ease, color 0.4s ease;
+}
+
+a {
+  color: inherit;
 }
 
 header,
 footer {
   text-align: center;
   padding: 1.5rem 1rem;
-  background: rgba(15, 23, 42, 0.8);
+  background: var(--header-footer-bg);
   backdrop-filter: blur(10px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  border-bottom: 1px solid var(--border-color);
 }
 
 footer {
   margin-top: auto;
-  border-top: 1px solid rgba(148, 163, 184, 0.2);
+  border-top: 1px solid var(--border-color);
   border-bottom: none;
   font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.8);
+  color: var(--text-tertiary);
 }
 
 main {
@@ -40,29 +83,182 @@ main {
   gap: 1.5rem;
 }
 
+.app-selection header {
+  padding-bottom: 1rem;
+}
+
+.app-selection main {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  max-width: 960px;
+}
+
 h1 {
   margin: 0 0 0.5rem;
   font-size: clamp(2rem, 4vw, 2.75rem);
 }
 
+h2 {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  color: var(--text-primary);
+}
+
 p {
   margin: 0;
   line-height: 1.6;
+  color: var(--text-secondary);
+}
+
+.app-selection .intro p {
+  max-width: 640px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+.app-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.app-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 1.5rem;
+  padding: 1.75rem;
+  border-radius: 18px;
+  background: var(--surface-strong-bg);
+  border: 1px solid var(--card-border);
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.app-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 25px 45px rgba(15, 23, 42, 0.12);
+  border-color: var(--card-hover);
+}
+
+.app-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.app-card ul {
+  margin: 1rem 0 0;
+  padding-left: 1.1rem;
+  color: var(--muted-text);
+  line-height: 1.6;
+}
+
+.app-card li + li {
+  margin-top: 0.35rem;
+}
+
+.app-card-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.6rem;
+  font-size: 0.75rem;
+  border-radius: 999px;
+  background: var(--tag-bg);
+  color: var(--accent-start);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.app-card-tag--muted {
+  background: var(--tag-muted-bg);
+  color: var(--text-tertiary);
+}
+
+.app-card-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  align-items: flex-start;
+}
+
+.app-card-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
+  color: #fff;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+.app-card-action:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 15px 25px var(--accent-shadow);
+}
+
+.app-card--disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.app-card--disabled .app-card-action {
+  background: var(--surface-muted-bg);
+  color: var(--text-tertiary);
+  box-shadow: none;
+  cursor: default;
+}
+
+.app-card--disabled:hover {
+  transform: none;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+  border-color: var(--card-border);
+}
+
+.top-nav {
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 1rem;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  background: rgba(59, 130, 246, 0.12);
+  color: var(--accent-start);
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-decoration: none;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.back-link:hover {
+  background: rgba(59, 130, 246, 0.22);
+  transform: translateX(-2px);
 }
 
 .uploader {
   position: relative;
-  border: 2px dashed rgba(148, 163, 184, 0.4);
+  border: 2px dashed var(--border-color);
   border-radius: 16px;
   padding: 3rem 1rem;
   text-align: center;
   transition: border-color 0.3s ease, background 0.3s ease;
-  background: rgba(15, 23, 42, 0.6);
+  background: var(--surface-bg);
 }
 
 .uploader.dragover {
-  border-color: #38bdf8;
-  background: rgba(59, 130, 246, 0.15);
+  border-color: var(--accent-end);
+  background: var(--surface-muted-bg);
 }
 
 #file-input {
@@ -77,17 +273,18 @@ p {
   flex-direction: column;
   gap: 0.5rem;
   pointer-events: none;
-  color: rgba(226, 232, 240, 0.85);
+  color: var(--text-secondary);
 }
 
 .label-main {
   font-size: 1.2rem;
   font-weight: 600;
+  color: var(--text-primary);
 }
 
 .label-sub {
   font-size: 0.95rem;
-  color: rgba(148, 163, 184, 0.8);
+  color: var(--text-tertiary);
 }
 
 .controls {
@@ -95,28 +292,32 @@ p {
   flex-wrap: wrap;
   align-items: center;
   gap: 1rem;
-  background: rgba(15, 23, 42, 0.6);
+  background: var(--surface-bg);
   padding: 1rem 1.25rem;
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid var(--border-color);
 }
 
 .file-info {
   flex: 1;
   min-width: 200px;
-  color: rgba(226, 232, 240, 0.85);
+  color: var(--text-secondary);
+}
+
+button,
+.app-card-action {
+  appearance: none;
+  border: none;
+  cursor: pointer;
 }
 
 button {
-  appearance: none;
-  border: none;
   padding: 0.9rem 1.8rem;
   border-radius: 999px;
-  background: linear-gradient(135deg, #2563eb, #38bdf8);
+  background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
   color: #fff;
   font-weight: 600;
   letter-spacing: 0.02em;
-  cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
 }
 
@@ -128,13 +329,13 @@ button:disabled {
 
 button:not(:disabled):hover {
   transform: translateY(-2px);
-  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.35);
+  box-shadow: 0 10px 25px var(--accent-shadow);
 }
 
 .progress {
-  background: rgba(15, 23, 42, 0.6);
+  background: var(--surface-bg);
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid var(--border-color);
   padding: 1rem 1.25rem;
 }
 
@@ -149,20 +350,20 @@ button:not(:disabled):hover {
 .status {
   margin-top: 0.75rem;
   font-size: 0.95rem;
-  color: rgba(226, 232, 240, 0.85);
+  color: var(--text-secondary);
 }
 
 .result,
 .log {
-  background: rgba(15, 23, 42, 0.6);
+  background: var(--surface-bg);
   border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  border: 1px solid var(--border-color);
   padding: 1.25rem 1.5rem;
 }
 
 .result p {
   margin: 0;
-  color: rgba(226, 232, 240, 0.8);
+  color: var(--text-secondary);
 }
 
 .download-list {
@@ -179,21 +380,21 @@ button:not(:disabled):hover {
   gap: 1rem;
   padding: 0.75rem 1rem;
   border-radius: 12px;
-  background: rgba(30, 41, 59, 0.75);
-  color: #38bdf8;
+  background: var(--surface-muted-bg);
+  color: var(--accent-end);
   font-weight: 600;
   text-decoration: none;
   transition: background 0.2s ease, color 0.2s ease;
 }
 
 .download-list a:hover {
-  background: rgba(59, 130, 246, 0.2);
-  color: #7dd3fc;
+  background: var(--card-hover);
+  color: var(--accent-hover);
 }
 
 .download-size {
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.7);
+  color: var(--text-tertiary);
   font-weight: 500;
 }
 
@@ -204,8 +405,8 @@ button:not(:disabled):hover {
   max-height: 240px;
   overflow-y: auto;
   font-size: 0.85rem;
-  color: rgba(148, 163, 184, 0.9);
-  background: rgba(15, 23, 42, 0.45);
+  color: var(--muted-text);
+  background: var(--surface-muted-bg);
   padding: 1rem;
   border-radius: 10px;
 }
@@ -222,5 +423,9 @@ button:not(:disabled):hover {
 
   button {
     width: 100%;
+  }
+
+  .app-card {
+    padding: 1.5rem;
   }
 }


### PR DESCRIPTION
## Summary
- introduce a new app selection landing page for the audio and video toolkit
- move the batch audio extractor into its own page with navigation back to the selector
- refresh global styles with system-aware light and dark themes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2894a60d083329f492cc8817cbf45