### PR TITLE
Fix converter UI handling and mobile file filters

### DIFF
--- a/converter.html
+++ b/converter.html
@@ -109,12 +109,12 @@
             <div class="field">
               <label for="video-quality-select">视频质量</label>
               <select id="video-quality-select">
+                <option value="lossless">无损</option>
                 <option value="ultra">极高</option>
                 <option value="high">高</option>
                 <option value="medium" selected>中</option>
                 <option value="low">低</option>
                 <option value="verylow">极低</option>
-                <option value="lossless">无损</option>
                 <option value="custom">自定义</option>
               </select>
             </div>
@@ -143,12 +143,12 @@
             <div class="field">
               <label for="audio-quality-select">音频质量</label>
               <select id="audio-quality-select">
+                <option value="lossless">无损</option>
                 <option value="ultra">极高</option>
                 <option value="high">高</option>
                 <option value="medium" selected>中</option>
                 <option value="low">低</option>
                 <option value="verylow">极低</option>
-                <option value="lossless">无损</option>
                 <option value="custom">自定义</option>
               </select>
             </div>

--- a/converter.js
+++ b/converter.js
@@ -146,12 +146,45 @@ const videoMimeTypes = [
   "application/x-zip-compressed",
 ];
 
-const audioAcceptTypes = `${audioMimeTypes.join(",")},${Array.from(audioExtensions)
-  .map((ext) => `.${ext}`)
-  .join(",")},.zip`;
-const videoAcceptTypes = `${videoMimeTypes.join(",")},${Array.from(videoExtensions)
-  .map((ext) => `.${ext}`)
-  .join(",")},.zip`;
+const isIOSDevice =
+  typeof navigator !== "undefined" &&
+  (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
+    (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
+
+const iosAudioUniformTypes = ["public.audio", "public.mpeg-4-audio"];
+const iosVideoUniformTypes = [
+  "public.movie",
+  "public.video",
+  "org.matroska.mkv",
+  "com.apple.quicktime-movie",
+];
+const iosZipUniformTypes = ["com.pkware.zip-archive", "public.zip-archive"];
+
+const baseAudioAcceptList = [
+  ...audioMimeTypes,
+  ...Array.from(audioExtensions).map((ext) => `.${ext}`),
+  ".zip",
+];
+
+const baseVideoAcceptList = [
+  ...videoMimeTypes,
+  ...Array.from(videoExtensions).map((ext) => `.${ext}`),
+  ".zip",
+];
+
+const buildAcceptList = (baseList, iosSpecific = []) => {
+  const items = new Set(baseList);
+  if (isIOSDevice) {
+    iosZipUniformTypes.forEach((type) => items.add(type));
+    iosSpecific.forEach((type) => items.add(type));
+  }
+  return Array.from(items).join(",");
+};
+
+const getAcceptTypesForMode = (mode) =>
+  mode === MODES.AUDIO
+    ? buildAcceptList(baseAudioAcceptList, iosAudioUniformTypes)
+    : buildAcceptList(baseVideoAcceptList, iosVideoUniformTypes);
 
 const modeDescriptions = {
   [MODES.AUDIO]: "支持音频文件与 ZIP 压缩包，所有处理均在本地完成",
@@ -482,7 +515,7 @@ const updateModeTabs = () => {
 };
 
 const updateFileInputForMode = ({ resetValue = false } = {}) => {
-  const acceptValue = currentMode === MODES.AUDIO ? audioAcceptTypes : videoAcceptTypes;
+  const acceptValue = getAcceptTypesForMode(currentMode);
   if (fileInput.accept !== acceptValue) {
     fileInput.accept = acceptValue;
     try {
@@ -637,6 +670,13 @@ const selectFiles = (files = []) => {
   state.videoEntriesWithAudio = false;
   state.results = [];
   state.config = null;
+  if (validFiles.length === 0) {
+    try {
+      fileInput.value = "";
+    } catch (error) {
+      // ignore inability to reset programmatically
+    }
+  }
   if (ffmpegReady) {
     cleanupTempFiles().catch((error) => {
       console.warn("清理临时文件时出错", error);
@@ -954,6 +994,9 @@ const populateSelect = (select, options, { includeCopyForAny = false } = {}) => 
 const getAudioContainerByValue = (value) => audioContainers.find((item) => item.value === value);
 const getVideoContainerByValue = (value) => videoContainers.find((item) => item.value === value);
 
+const shouldHideAudioContainerGroup = () =>
+  currentMode === MODES.VIDEO || (state.hasVideoEntries && !state.hasAudioEntries);
+
 const prepareAudioSelects = () => {
   if (!state.hasAudioEntries && !state.videoEntriesWithAudio) {
     audioOptions.hidden = true;
@@ -962,7 +1005,7 @@ const prepareAudioSelects = () => {
   }
   audioOptions.hidden = false;
 
-  const hideContainerGroup = state.hasVideoEntries && !state.hasAudioEntries;
+  const hideContainerGroup = shouldHideAudioContainerGroup();
   toggleFieldVisibility(audioContainerGroup, hideContainerGroup);
 
   if (!hideContainerGroup) {
@@ -991,7 +1034,7 @@ const prepareVideoSelects = () => {
 };
 
 const updateAudioCodecOptions = () => {
-  const hideContainerGroup = state.hasVideoEntries && !state.hasAudioEntries;
+  const hideContainerGroup = shouldHideAudioContainerGroup();
   toggleFieldVisibility(audioContainerGroup, hideContainerGroup);
   if (hideContainerGroup) {
     const container = getVideoContainerByValue(videoContainerSelect.value) || { audioCodecs: [] };
@@ -1706,5 +1749,10 @@ updateFileInputForMode();
 updateFileInfo();
 updateAnalyzeAndClearState();
 renderResults(state);
+
+analysisSection.hidden = true;
+configSection.hidden = true;
+updateAudioQualityVisibility();
+updateVideoQualityVisibility();
 
 setStatus("等待操作");

--- a/styles.css
+++ b/styles.css
@@ -310,6 +310,15 @@ p {
   box-shadow: none;
   transform: none;
   transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.mode-tab:focus {
+  outline: none;
+}
+
+.mode-tab:focus-visible {
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
 }
 
 .mode-tab:not(:disabled):hover {
@@ -328,6 +337,10 @@ p {
 .mode-tab.is-active:not(:disabled):hover {
   box-shadow: 0 16px 32px var(--accent-shadow);
   transform: none;
+}
+
+.mode-tab.is-active:focus-visible {
+  box-shadow: 0 0 0 3px rgba(255, 255, 255, 0.45), 0 16px 32px var(--accent-shadow);
 }
 
 .controls {
@@ -369,7 +382,7 @@ button,
   cursor: pointer;
 }
 
-button {
+button:not(.mode-tab) {
   padding: 0.9rem 1.8rem;
   border-radius: 999px;
   background: linear-gradient(135deg, var(--accent-start), var(--accent-end));
@@ -385,9 +398,13 @@ button:disabled {
   box-shadow: none;
 }
 
-button:not(:disabled):hover {
+button:not(.mode-tab):not(:disabled):hover {
   transform: translateY(-2px);
   box-shadow: 0 10px 25px var(--accent-shadow);
+}
+
+[hidden] {
+  display: none !important;
 }
 
 .is-hidden {


### PR DESCRIPTION
## Summary
- adjust the converter tabs and hidden sections styling to improve readability and initial state
- update quality option ordering and hide audio container controls while in video mode
- expand file acceptance handling, including iOS-specific UTType hints and stricter rejection of unsupported uploads

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3bf46a58483329522f0c231d0e8d0