### PR TITLE
Fix opus conversions on iOS Safari

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -166,6 +166,11 @@ const iosVideoUniformTypes = [
 ];
 const iosZipUniformTypes = ["com.pkware.zip-archive", "public.zip-archive"];
 
+const supportsSharedArrayBuffer = typeof SharedArrayBuffer === "function";
+const supportsThreading = supportsSharedArrayBuffer && typeof Atomics === "object";
+const DEFAULT_AUDIO_THREADS = supportsThreading && !isIOSDevice ? 2 : 1;
+const DEFAULT_VIDEO_THREADS = supportsThreading ? 2 : 1;
+
 const baseAudioAcceptList = [
   ...audioMimeTypes,
   ...Array.from(audioExtensions).map((ext) => `.${ext}`),
@@ -227,8 +232,6 @@ const videoQualityProfiles = {
   low: { crf: 28, preset: "faster", scaleHeight: 720 },
   verylow: { crf: 32, preset: "veryfast", scaleHeight: 480 },
 };
-
-const DEFAULT_VIDEO_THREADS = 2;
 
 const audioContainers = [
   {
@@ -1280,16 +1283,29 @@ const ensureLosslessApplicable = (qualitySetting, targetCodec, sourceCodec) => {
   return { mode: "bitrate", bitrate: audioQualityProfiles.ultra.bitrate };
 };
 
+const applyAudioEncodingArgs = (args, codec, quality) => {
+  if (codec === "copy") {
+    args.push("-c:a", "copy");
+    return;
+  }
+
+  args.push("-c:a", codec);
+  if (quality?.mode === "bitrate" && quality.bitrate) {
+    args.push("-b:a", `${quality.bitrate}k`);
+  }
+
+  if (codec === "libopus") {
+    args.push("-application", "audio");
+  }
+
+  if (Number.isFinite(DEFAULT_AUDIO_THREADS) && DEFAULT_AUDIO_THREADS > 0) {
+    args.push("-threads:a", `${DEFAULT_AUDIO_THREADS}`);
+  }
+};
+
 const buildAudioArgs = (entry, outputName, settings) => {
   const args = ["-y", "-i", entry.inputName];
-  if (settings.audioCodec === "copy") {
-    args.push("-c:a", "copy");
-  } else {
-    args.push("-c:a", settings.audioCodec);
-    if (settings.audioQuality.mode === "bitrate" && settings.audioQuality.bitrate) {
-      args.push("-b:a", `${settings.audioQuality.bitrate}k`);
-    }
-  }
+  applyAudioEncodingArgs(args, settings.audioCodec, settings.audioQuality);
   args.push("-vn");
   args.push(outputName);
   return args;
@@ -1346,14 +1362,7 @@ const buildVideoArgs = (entry, outputName, settings) => {
     }
   }
   if (settings.includeAudio) {
-    if (settings.audioCodec === "copy") {
-      args.push("-c:a", "copy");
-    } else {
-      args.push("-c:a", settings.audioCodec);
-      if (settings.audioQuality.mode === "bitrate" && settings.audioQuality.bitrate) {
-        args.push("-b:a", `${settings.audioQuality.bitrate}k`);
-      }
-    }
+    applyAudioEncodingArgs(args, settings.audioCodec, settings.audioQuality);
   } else {
     args.push("-an");
   }


### PR DESCRIPTION
## Summary
- detect whether WebAssembly threading is supported and limit audio encoder threads when unavailable or on iOS
- reuse a helper to apply audio encoding options so opus conversions always set a safe thread count and opus-specific parameters
- ensure video conversions that re-encode audio also benefit from the safer audio encoder defaults

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d3d71e63348332bb2ef04786aa231d