### PR TITLE
Force opus muxer for Opus conversions

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1291,6 +1291,12 @@ const buildAudioArgs = (entry, outputName, settings) => {
     }
   }
   args.push("-vn");
+  if (settings.audioCodec === "libopus") {
+    const extension = getExtension(outputName);
+    if (["ogg", "opus"].includes(extension)) {
+      args.push("-f", "opus");
+    }
+  }
   args.push(outputName);
   return args;
 };


### PR DESCRIPTION
## Summary
- ensure audio conversions that encode with libopus explicitly select the Opus muxer when targeting .ogg or .opus containers
- improve reliability of Opus exports on platforms (such as iOS Safari) that previously stalled during muxing

## Testing
- not run (project does not provide automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d3de1864c08332a2523cc581b56dd5