### PR TITLE
Adjust Opus conversion arguments

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -1280,17 +1280,38 @@ const ensureLosslessApplicable = (qualitySetting, targetCodec, sourceCodec) => {
   return { mode: "bitrate", bitrate: audioQualityProfiles.ultra.bitrate };
 };
 
+const audioCodecExtraArgs = {
+  libopus: ["-application", "audio", "-ar", "48000"],
+};
+
+const audioContainerExtraArgs = {
+  opus: ["-map_metadata", "-1", "-f", "ogg"],
+  ogg: ["-map_metadata", "-1", "-f", "ogg"],
+};
+
 const buildAudioArgs = (entry, outputName, settings) => {
   const args = ["-y", "-i", entry.inputName];
-  if (settings.audioCodec === "copy") {
+  const audioCodec = settings.audioCodec || "copy";
+  const audioQuality = settings.audioQuality || { mode: "bitrate" };
+  const container = (settings.container || "").toLowerCase();
+  const codecExtras = audioCodecExtraArgs[audioCodec?.toLowerCase?.() || ""];
+  const containerExtras = audioContainerExtraArgs[container];
+
+  if (audioCodec === "copy") {
     args.push("-c:a", "copy");
   } else {
-    args.push("-c:a", settings.audioCodec);
-    if (settings.audioQuality.mode === "bitrate" && settings.audioQuality.bitrate) {
-      args.push("-b:a", `${settings.audioQuality.bitrate}k`);
+    args.push("-c:a", audioCodec);
+    if (audioQuality.mode === "bitrate" && audioQuality.bitrate) {
+      args.push("-b:a", `${audioQuality.bitrate}k`);
     }
   }
+  if (codecExtras) {
+    args.push(...codecExtras);
+  }
   args.push("-vn");
+  if (containerExtras) {
+    args.push(...containerExtras);
+  }
   args.push(outputName);
   return args;
 };
@@ -1352,6 +1373,10 @@ const buildVideoArgs = (entry, outputName, settings) => {
       args.push("-c:a", settings.audioCodec);
       if (settings.audioQuality.mode === "bitrate" && settings.audioQuality.bitrate) {
         args.push("-b:a", `${settings.audioQuality.bitrate}k`);
+      }
+      const codecExtras = audioCodecExtraArgs[settings.audioCodec?.toLowerCase?.() || ""];
+      if (codecExtras) {
+        args.push(...codecExtras);
       }
     }
   } else {
@@ -1476,6 +1501,7 @@ const convertEntries = async () => {
         ? buildAudioArgs({ ...entry, inputName }, outputName, {
             audioCodec: settings.audioCodec,
             audioQuality: settings.audioQuality,
+            container: targetContainer,
           })
         : buildVideoArgs({ ...entry, inputName }, outputName, {
             videoCodec: settings.videoCodec,


### PR DESCRIPTION
## Summary
- ensure Opus outputs request the Ogg muxer, drop incompatible metadata, and force libopus to encode at 48 kHz for the wasm build
- apply codec-specific audio extras when re-encoding tracks during video conversions so libopus receives the same tuning

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3f6402dd483329dc89278dfc0554a