### PR TITLE
Improve upload flow with append support and cleanup

### DIFF
--- a/converter.html
+++ b/converter.html
@@ -41,7 +41,6 @@
         <input
           type="file"
           id="file-input"
-          accept="audio/*,.aac,.ac3,.aiff,.alac,.amr,.ape,.dts,.flac,.m2a,.m4a,.mka,.mp2,.mp3,.ogg,.opus,.wav,.wma,.wv,.zip,application/zip"
           multiple
         />
         <label for="file-input" id="file-label">
@@ -51,7 +50,6 @@
       </section>
       <section class="controls">
         <div class="file-info" id="file-info">尚未选择文件</div>
-        <button id="analyze-btn" type="button" disabled>分析文件</button>
         <button id="clear-btn" type="button" class="ghost-button" disabled>清空上传</button>
       </section>
       <section class="analysis" id="analysis-section" hidden>
@@ -61,14 +59,37 @@
           <table>
             <thead>
               <tr>
-                <th scope="col">文件</th>
-                <th scope="col">类型</th>
-                <th scope="col" class="analysis-size">大小</th>
-                <th scope="col">容器</th>
-                <th scope="col" class="column-video-only">分辨率</th>
-                <th scope="col" class="column-video-only">帧率</th>
-                <th scope="col" class="column-video-only">视频编码</th>
-                <th scope="col">音频编码</th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="displayName">文件</button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="type">类型</button>
+                </th>
+                <th scope="col" class="analysis-size">
+                  <button type="button" class="sort-button" data-sort-key="size">大小</button>
+                </th>
+                <th scope="col" class="analysis-time">
+                  <button type="button" class="sort-button" data-sort-key="uploadedAt">上传时间</button>
+                </th>
+                <th scope="col" class="analysis-time">
+                  <button type="button" class="sort-button" data-sort-key="createdAt">创建时间</button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="container">容器</button>
+                </th>
+                <th scope="col" class="column-video-only">
+                  <button type="button" class="sort-button" data-sort-key="resolution">分辨率</button>
+                </th>
+                <th scope="col" class="column-video-only">
+                  <button type="button" class="sort-button" data-sort-key="frameRate">帧率</button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="videoCodec">视频编码</button>
+                </th>
+                <th scope="col">
+                  <button type="button" class="sort-button" data-sort-key="audioCodec">音频编码</button>
+                </th>
+                <th scope="col" class="analysis-actions">操作</th>
               </tr>
             </thead>
             <tbody id="analysis-body"></tbody>
@@ -185,6 +206,24 @@
         <pre id="log-output"></pre>
       </section>
     </main>
+    <div class="modal" id="detail-modal" hidden>
+      <div class="modal-backdrop" data-close="true"></div>
+      <div
+        class="modal-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="detail-modal-title"
+        tabindex="-1"
+      >
+        <header class="modal-header">
+          <h3 id="detail-modal-title">文件详情</h3>
+          <button type="button" class="modal-close" id="detail-modal-close" aria-label="关闭详情">
+            &times;
+          </button>
+        </header>
+        <div class="modal-content" id="detail-modal-content"></div>
+      </div>
+    </div>
     <footer>
       <p>所有操作均在浏览器中完成，不会上传到服务器。</p>
     </footer>

--- a/converter.js
+++ b/converter.js
@@ -4,7 +4,6 @@ import { unzipSync, zipSync } from "./vendor/fflate.min.js";
 
 const dropZone = document.getElementById("drop-zone");
 let fileInput = document.getElementById("file-input");
-const analyzeBtn = document.getElementById("analyze-btn");
 const convertBtn = document.getElementById("convert-btn");
 const fileInfo = document.getElementById("file-info");
 const statusEl = document.getElementById("status");
@@ -22,6 +21,14 @@ const analysisSection = document.getElementById("analysis-section");
 const analysisBody = document.getElementById("analysis-body");
 const analysisSummary = document.getElementById("analysis-summary");
 const configSection = document.getElementById("config-section");
+const sortButtons = document.querySelectorAll(".sort-button");
+
+const detailModal = document.getElementById("detail-modal");
+const detailModalDialog = detailModal?.querySelector(".modal-dialog");
+const detailModalContent = document.getElementById("detail-modal-content");
+const detailModalClose = document.getElementById("detail-modal-close");
+const detailModalBackdrop = detailModal?.querySelector(".modal-backdrop");
+const detailModalTitle = document.getElementById("detail-modal-title");
 
 const presetSelect = document.getElementById("preset-select");
 const presetContainerGroup = document.getElementById("preset-container-group");
@@ -48,6 +55,22 @@ let ffmpegReady = false;
 const ffmpegLogBuffer = [];
 const MAX_LOG_BUFFER = 5000;
 
+const DEFAULT_SORT_KEY = "uploadedAt";
+
+const createDefaultSortState = () => ({
+  key: DEFAULT_SORT_KEY,
+  direction: "desc",
+  isDefault: true,
+});
+
+let isAnalyzing = false;
+let lastFocusedElement = null;
+let entryIdCounter = 0;
+
+const textCollator = typeof Intl !== "undefined" && Intl.Collator
+  ? new Intl.Collator("zh-Hans", { numeric: true, sensitivity: "base" })
+  : null;
+
 const MODES = {
   AUDIO: "audio",
   VIDEO: "video",
@@ -61,6 +84,7 @@ const createModeState = () => ({
   videoEntriesWithAudio: false,
   results: [],
   config: null,
+  analysisSort: createDefaultSortState(),
 });
 
 const modeStates = {
@@ -122,16 +146,90 @@ const videoExtensions = new Set([
   "wmv",
 ]);
 
+const gatherUniformTypesFromMap = (extensionSet, mapping) => {
+  const values = new Set();
+  extensionSet.forEach((ext) => {
+    const mapped = mapping?.[ext];
+    if (Array.isArray(mapped)) {
+      mapped.filter(Boolean).forEach((item) => values.add(item));
+    }
+  });
+  return values;
+};
+
+const buildIOSUniformTypeList = (baseList, extensionSet, mapping) => {
+  const items = new Set((baseList || []).filter(Boolean));
+  const mappedValues = gatherUniformTypesFromMap(extensionSet, mapping);
+  mappedValues.forEach((value) => items.add(value));
+  return Array.from(items);
+};
+
+const iosAudioUniformTypeMap = {
+  aac: ["public.aac-audio"],
+  ac3: ["com.dolby.ac-3-audio"],
+  aiff: ["public.aiff-audio", "public.aifc-audio"],
+  alac: ["com.apple.coreaudio-format"],
+  amr: ["org.3gpp.adaptive-multi-rate-audio"],
+  ape: ["com.monkeysaudio.ape-audio"],
+  dts: ["com.dts.audio"],
+  flac: ["org.xiph.flac"],
+  m2a: ["public.mpeg-2-audio"],
+  m4a: ["public.mpeg-4-audio"],
+  mka: ["org.matroska.audio"],
+  mp2: ["public.mp2"],
+  mp3: ["public.mp3"],
+  ogg: ["org.xiph.ogg-audio"],
+  opus: ["org.xiph.opus"],
+  wav: ["com.microsoft.waveform-audio"],
+  wma: ["com.microsoft.windows-media-wma"],
+  wv: ["com.wavpack.audio"],
+};
+
+const iosVideoUniformTypeMap = {
+  "3g2": ["public.3gpp2"],
+  "3gp": ["public.3gpp"],
+  avi: ["public.avi", "com.microsoft.avi"],
+  flv: ["com.adobe.flash-video"],
+  m2ts: ["com.sony.m2ts", "public.mpeg-2-transport-stream"],
+  m4v: ["com.apple.m4v-video"],
+  mkv: ["org.matroska.mkv", "org.matroska.video", "org.matroska.matroska"],
+  mov: ["com.apple.quicktime-movie"],
+  mp4: ["public.mpeg-4"],
+  mpeg: ["public.mpeg"],
+  mpg: ["public.mpeg"],
+  mts: ["com.sony.mts", "public.mpeg-2-transport-stream"],
+  mxf: ["com.sony.mxf"],
+  ts: ["public.mpeg-2-transport-stream"],
+  vob: ["com.apple.vob-video"],
+  webm: ["org.webmproject.webm"],
+  wmv: ["com.microsoft.windows-media-wmv"],
+};
+
 const audioMimeTypes = [
-  "audio/*",
   "audio/aac",
   "audio/x-aac",
-  "audio/mp4",
-  "audio/x-m4a",
+  "audio/aiff",
+  "audio/x-aiff",
+  "audio/aifc",
+  "audio/x-aifc",
+  "audio/amr",
+  "audio/3gpp",
+  "audio/3gpp2",
+  "audio/flac",
+  "audio/x-flac",
   "audio/mpeg",
   "audio/ogg",
+  "audio/opus",
   "audio/wav",
-  "audio/flac",
+  "audio/x-wav",
+  "audio/wave",
+  "audio/vnd.wave",
+  "audio/vnd.dts",
+  "audio/vnd.dts.hd",
+  "audio/x-ms-wma",
+  "audio/x-m4a",
+  "audio/ape",
+  "audio/x-ape",
   "application/zip",
   "application/x-zip-compressed",
 ];
@@ -151,19 +249,30 @@ const isIOSDevice =
   (/iPad|iPhone|iPod/.test(navigator.userAgent) ||
     (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1));
 
-const iosAudioUniformTypes = [
-  "public.audio",
-  "public.mpeg-4-audio",
-  "org.matroska.audio",
-];
-const iosVideoUniformTypes = [
-  "public.movie",
-  "public.video",
-  "org.matroska.mkv",
-  "org.matroska.video",
-  "org.webmproject.webm",
-  "com.apple.quicktime-movie",
-];
+const iosAudioUniformTypes = buildIOSUniformTypeList(
+  [
+    "public.audio",
+    "public.mpeg-4-audio",
+    "org.matroska.audio",
+    "com.apple.coreaudio-format",
+  ],
+  audioExtensions,
+  iosAudioUniformTypeMap,
+);
+
+const iosVideoUniformTypes = buildIOSUniformTypeList(
+  [
+    "public.movie",
+    "public.video",
+    "org.matroska.mkv",
+    "org.matroska.video",
+    "org.webmproject.webm",
+    "com.apple.quicktime-movie",
+  ],
+  videoExtensions,
+  iosVideoUniformTypeMap,
+);
+
 const iosZipUniformTypes = ["com.pkware.zip-archive", "public.zip-archive"];
 
 const baseAudioAcceptList = [
@@ -178,19 +287,29 @@ const baseVideoAcceptList = [
   ".zip",
 ];
 
-const buildAcceptList = (baseList, iosSpecific = []) => {
+const buildAcceptList = (baseList, iosSpecific = [], options = {}) => {
+  const { iosFallbackTypes = [] } = options;
   const items = new Set(baseList);
   if (isIOSDevice) {
     iosZipUniformTypes.forEach((type) => items.add(type));
     iosSpecific.forEach((type) => items.add(type));
+    iosFallbackTypes.forEach((type) => items.add(type));
   }
   return Array.from(items).join(",");
 };
 
-const getAcceptTypesForMode = (mode) =>
-  mode === MODES.AUDIO
-    ? buildAcceptList(baseAudioAcceptList, iosAudioUniformTypes)
-    : buildAcceptList(baseVideoAcceptList, iosVideoUniformTypes);
+const getAcceptTypesForMode = (mode) => {
+  if (mode === MODES.AUDIO) {
+    return buildAcceptList(baseAudioAcceptList, iosAudioUniformTypes);
+  }
+  if (mode === MODES.VIDEO) {
+    if (isIOSDevice) {
+      return "";
+    }
+    return buildAcceptList(baseVideoAcceptList, iosVideoUniformTypes);
+  }
+  return "";
+};
 
 const modeDescriptions = {
   [MODES.AUDIO]: "支持音频文件与 ZIP 压缩包，所有处理均在本地完成",
@@ -418,6 +537,85 @@ const formatBytes = (bytes) => {
   return `${(bytes / 1024 ** exponent).toFixed(exponent === 0 ? 0 : 2)} ${units[exponent]}`;
 };
 
+const formatDateTime = (timestamp) => {
+  if (!Number.isFinite(timestamp)) return "未知";
+  try {
+    const formatter = typeof Intl !== "undefined" && Intl.DateTimeFormat
+      ? new Intl.DateTimeFormat("zh-CN", {
+          dateStyle: "medium",
+          timeStyle: "medium",
+        })
+      : null;
+    const date = new Date(timestamp);
+    if (formatter) {
+      return formatter.format(date);
+    }
+    return date.toLocaleString();
+  } catch (error) {
+    return new Date(timestamp).toLocaleString();
+  }
+};
+
+const formatFrameRate = (value) => {
+  if (!Number.isFinite(value) || value <= 0) return "未知";
+  return `${value % 1 === 0 ? value.toFixed(0) : value.toFixed(2)} fps`;
+};
+
+const formatDuration = (seconds) => {
+  if (!Number.isFinite(seconds) || seconds <= 0) return "未知";
+  const totalMilliseconds = Math.round(seconds * 1000);
+  const totalSeconds = Math.floor(totalMilliseconds / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  const fractional = totalMilliseconds % 1000;
+  const parts = [];
+  if (hours) {
+    parts.push(String(hours).padStart(2, "0"));
+    parts.push(String(minutes).padStart(2, "0"));
+  } else {
+    parts.push(String(minutes));
+  }
+  parts.push(String(secs).padStart(2, "0"));
+  let formatted = parts.join(":");
+  if (fractional) {
+    const fractionalStr = String(Math.floor(fractional / 10)).padStart(2, "0");
+    formatted = `${formatted}.${fractionalStr}`;
+  }
+  return formatted;
+};
+
+const formatBitrate = (bps) => {
+  if (!Number.isFinite(bps) || bps <= 0) return "未知";
+  if (bps >= 1_000_000) {
+    return `${(bps / 1_000_000).toFixed(2)} Mbps`;
+  }
+  if (bps >= 1_000) {
+    return `${(bps / 1_000).toFixed(0)} kbps`;
+  }
+  return `${Math.round(bps)} bps`;
+};
+
+const formatMetadataDate = (value) => {
+  if (!value) return "";
+  const timestamp = Date.parse(value);
+  if (Number.isFinite(timestamp)) {
+    return formatDateTime(timestamp);
+  }
+  return value;
+};
+
+const normalizeMetadataValue = (value) => {
+  if (typeof value !== "string") {
+    return "";
+  }
+  const trimmed = value.trim();
+  if (!trimmed || /^n\/?a$/i.test(trimmed)) {
+    return "";
+  }
+  return trimmed;
+};
+
 const sanitizeName = (name, fallback = "file") => {
   if (!name) return fallback;
   const normalized = typeof name.normalize === "function" ? name.normalize("NFC") : name;
@@ -446,9 +644,117 @@ const shortenLabel = (label) => {
   return label.length > 48 ? `${label.slice(0, 45)}...` : label;
 };
 
+const splitDisplayName = (name = "") => {
+  const normalized = String(name).replace(/\\/g, "/");
+  const lastSlash = normalized.lastIndexOf("/");
+  const prefix = lastSlash >= 0 ? normalized.slice(0, lastSlash + 1) : "";
+  const filePart = lastSlash >= 0 ? normalized.slice(lastSlash + 1) : normalized;
+  const ext = getExtension(filePart);
+  const baseWithSuffix = ext ? filePart.slice(0, filePart.length - ext.length - 1) : filePart;
+  const suffixMatch = baseWithSuffix.match(/^(.*)\((\d+)\)$/);
+  let base = baseWithSuffix;
+  let suffixIndex = 0;
+  if (suffixMatch) {
+    base = suffixMatch[1];
+    suffixIndex = Number(suffixMatch[2]) || 0;
+  }
+  return {
+    prefix,
+    base,
+    ext,
+    suffixIndex,
+  };
+};
+
+const buildDisplayNameWithSuffix = (prefix, base, ext, index) => {
+  const safeBase = typeof base === "string" ? base : "";
+  const suffix = index > 0 ? `(${index})` : "";
+  const filePart = ext ? `${safeBase}${suffix}.${ext}` : `${safeBase}${suffix}`;
+  return `${prefix}${filePart}`;
+};
+
+const ensureUniqueDisplayNames = (existingEntries = [], newEntries = []) => {
+  if (!Array.isArray(newEntries) || newEntries.length === 0) {
+    return;
+  }
+  const usedNames = new Set();
+  const nextIndexMap = new Map();
+
+  const buildKey = (parts) =>
+    `${(parts.prefix || "").toLowerCase()}|${(parts.base || "").toLowerCase()}|${(parts.ext || "").toLowerCase()}`;
+
+  const registerName = (name) => {
+    if (!name) return;
+    const parts = splitDisplayName(name);
+    const key = buildKey(parts);
+    const candidateNext = (parts.suffixIndex || 0) + 1;
+    const currentNext = nextIndexMap.get(key) || 1;
+    nextIndexMap.set(key, Math.max(currentNext, candidateNext));
+    usedNames.add(name.toLowerCase());
+  };
+
+  existingEntries.forEach((entry) => {
+    if (entry && entry.displayName) {
+      registerName(entry.displayName);
+    }
+  });
+
+  newEntries.forEach((entry) => {
+    if (!entry || !entry.displayName) return;
+    const originalName = entry.displayName;
+    const lowerName = originalName.toLowerCase();
+    const parts = splitDisplayName(originalName);
+    const key = buildKey(parts);
+    const initialNext = nextIndexMap.get(key) || 1;
+    if (!usedNames.has(lowerName)) {
+      usedNames.add(lowerName);
+      nextIndexMap.set(key, Math.max(initialNext, 1));
+      return;
+    }
+    let index = initialNext;
+    let candidate = originalName;
+    while (true) {
+      candidate = buildDisplayNameWithSuffix(parts.prefix, parts.base, parts.ext, index);
+      const candidateLower = candidate.toLowerCase();
+      if (!usedNames.has(candidateLower)) {
+        entry.displayName = candidate;
+        usedNames.add(candidateLower);
+        nextIndexMap.set(key, index + 1);
+        break;
+      }
+      index += 1;
+    }
+  });
+};
+
 const joinLabel = (...parts) => parts.filter(Boolean).join("/").replace(/\\/g, "/");
 
 const isZipFile = (name = "") => /\.zip$/i.test(name);
+
+const ensureTimestamp = (value) => (Number.isFinite(value) ? value : Date.now());
+
+const createUploadTracker = (base = Date.now()) => {
+  let counter = 0;
+  return {
+    next() {
+      const value = base + counter;
+      counter += 1;
+      return Number.isFinite(value) ? value : Date.now();
+    },
+  };
+};
+
+const getFileTimestamp = (file) => {
+  if (!file) return Date.now();
+  if (typeof file.lastModified === "number" && Number.isFinite(file.lastModified)) {
+    return file.lastModified;
+  }
+  const lastModifiedDate = file.lastModifiedDate;
+  if (lastModifiedDate instanceof Date && Number.isFinite(lastModifiedDate.valueOf())) {
+    return lastModifiedDate.valueOf();
+  }
+  return Date.now();
+};
 
 const isAudioFile = (file) => {
   if (!file) return false;
@@ -502,6 +808,17 @@ const clearResults = (modeState = state) => {
   renderResults(modeState);
 };
 
+const recalculateEntryFlags = () => {
+  const entries = Array.isArray(state.mediaEntries) ? state.mediaEntries : [];
+  state.hasVideoEntries = entries.some((entry) => entry.type === "video");
+  state.hasAudioEntries = entries.some((entry) => entry.type === "audio");
+  state.videoEntriesWithAudio = entries.some(
+    (entry) =>
+      entry.type === "video" &&
+      (entry.analysis?.hasAudio || Boolean(entry.analysis?.audioCodec)),
+  );
+};
+
 const clearLog = () => {
   logOutput.textContent = "";
   ffmpegLogBuffer.length = 0;
@@ -553,8 +870,7 @@ const anyUploadsExist = () =>
     (modeState) => modeState.selectedFiles.length || modeState.mediaEntries.length || modeState.results.length,
   );
 
-const updateAnalyzeAndClearState = () => {
-  analyzeBtn.disabled = state.selectedFiles.length === 0;
+const updateClearButtonState = () => {
   clearBtn.disabled = !anyUploadsExist();
 };
 
@@ -648,6 +964,7 @@ const rebuildFileInputElement = (acceptValue) => {
   newInput.type = "file";
   newInput.multiple = fileInput.multiple;
   newInput.id = fileInput.id;
+  newInput.disabled = fileInput.disabled;
   if (fileInput.name) {
     newInput.name = fileInput.name;
   }
@@ -691,7 +1008,142 @@ const loadFFmpeg = async () => {
   }
 };
 
+const getSortableValue = (entry, key) => {
+  if (!entry) return null;
+  switch (key) {
+    case "displayName":
+      return entry.displayName || "";
+    case "type":
+      return entry.type || "";
+    case "size":
+      return entry.file?.size ?? null;
+    case "uploadedAt":
+      return entry.uploadedAt ?? null;
+    case "createdAt":
+      return entry.createdAt ?? null;
+    case "container":
+      return entry.analysis?.container || null;
+    case "resolution":
+      if (entry.analysis?.width && entry.analysis?.height) {
+        return entry.analysis.width * 10000 + entry.analysis.height;
+      }
+      return null;
+    case "frameRate":
+      return Number.isFinite(entry.analysis?.frameRate) ? entry.analysis.frameRate : null;
+    case "videoCodec":
+      return entry.type === "video"
+        ? entry.analysis?.videoCodec || (entry.analysis?.hasVideo ? "未知" : null)
+        : null;
+    case "audioCodec":
+      if (entry.analysis?.audioCodec) {
+        return entry.analysis.audioCodec;
+      }
+      if (entry.analysis?.hasAudio === false) {
+        return null;
+      }
+      return entry.analysis?.hasAudio ? "未知" : null;
+    default:
+      return entry.originalIndex ?? null;
+  }
+};
+
+const compareEntriesForSort = (a, b, sortState) => {
+  if (!sortState) return 0;
+  const { key, direction } = sortState;
+  const multiplier = direction === "desc" ? -1 : 1;
+  const aValue = getSortableValue(a, key);
+  const bValue = getSortableValue(b, key);
+  const aIsNull = aValue === null || typeof aValue === "undefined";
+  const bIsNull = bValue === null || typeof bValue === "undefined";
+  if (aIsNull && !bIsNull) return 1;
+  if (!aIsNull && bIsNull) return -1;
+  if (!aIsNull && !bIsNull) {
+    if (typeof aValue === "number" && typeof bValue === "number") {
+      const diff = aValue - bValue;
+      if (diff !== 0) {
+        return diff * multiplier;
+      }
+    } else {
+      const aText = String(aValue);
+      const bText = String(bValue);
+      const diff = textCollator ? textCollator.compare(aText, bText) : aText.localeCompare(bText);
+      if (diff !== 0) {
+        return diff * multiplier;
+      }
+    }
+  }
+  return (a.originalIndex ?? 0) - (b.originalIndex ?? 0);
+};
+
+const sortEntriesForDisplay = (entries) => {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    return [];
+  }
+  const sortState = state.analysisSort || createDefaultSortState();
+  const sorted = Array.from(entries);
+  sorted.sort((a, b) => compareEntriesForSort(a, b, sortState));
+  return sorted;
+};
+
+const updateSortIndicators = () => {
+  if (!sortButtons || sortButtons.length === 0) return;
+  const sortState = state.analysisSort || createDefaultSortState();
+  sortButtons.forEach((button) => {
+    if (!button) return;
+    const key = button.dataset.sortKey;
+    const stateValue = sortState.key === key ? sortState.direction : "none";
+    button.dataset.sortState = stateValue;
+    if (stateValue === "asc" || stateValue === "desc") {
+      button.setAttribute("aria-pressed", "true");
+    } else {
+      button.setAttribute("aria-pressed", "false");
+    }
+    const headerCell = button.closest("th");
+    if (headerCell) {
+      if (stateValue === "asc") {
+        headerCell.setAttribute("aria-sort", "ascending");
+      } else if (stateValue === "desc") {
+        headerCell.setAttribute("aria-sort", "descending");
+      } else {
+        headerCell.removeAttribute("aria-sort");
+      }
+    }
+  });
+};
+
+const applySortForKey = (key) => {
+  if (!key) return;
+  const current = state.analysisSort || createDefaultSortState();
+  let nextState;
+  if (current.key === key) {
+    if (current.isDefault) {
+      nextState = { key, direction: "asc", isDefault: false };
+    } else if (current.direction === "asc") {
+      nextState = { key, direction: "desc", isDefault: false };
+    } else if (current.direction === "desc") {
+      nextState = createDefaultSortState();
+    }
+  } else {
+    nextState = { key, direction: "asc", isDefault: false };
+  }
+  if (!nextState) {
+    nextState = createDefaultSortState();
+  }
+  state.analysisSort = nextState;
+  if (state.mediaEntries.length) {
+    buildAnalysisTable(state.mediaEntries);
+  } else {
+    updateSortIndicators();
+  }
+};
+
 const selectFiles = (files = []) => {
+  closeDetailModal();
+  if (isAnalyzing) {
+    setStatus("正在分析当前文件，请稍候再上传新文件");
+    return;
+  }
+
   const validFiles = [];
   let rejectedCount = 0;
   for (const file of Array.from(files || [])) {
@@ -707,60 +1159,78 @@ const selectFiles = (files = []) => {
     }
   }
 
-  state.selectedFiles = validFiles;
-  state.mediaEntries = [];
-  state.hasVideoEntries = false;
-  state.hasAudioEntries = false;
-  state.videoEntriesWithAudio = false;
-  state.results = [];
-  state.config = null;
-  if (validFiles.length === 0) {
+  if (fileInput) {
     try {
       fileInput.value = "";
     } catch (error) {
       // ignore inability to reset programmatically
     }
   }
+
+  if (!validFiles.length) {
+    state.selectedFiles = [];
+    updateFileInfo();
+    if (rejectedCount > 0) {
+      const expectedLabel = currentMode === MODES.AUDIO ? "音频" : "视频";
+      setStatus(`已忽略 ${rejectedCount} 个非${expectedLabel}文件`);
+    } else if (!state.mediaEntries.length) {
+      setStatus("等待操作");
+    }
+    return;
+  }
+
+  const hasExistingEntries = state.mediaEntries.length > 0;
+  state.selectedFiles = validFiles;
+  if (!hasExistingEntries) {
+    state.analysisSort = createDefaultSortState();
+    analysisBody.innerHTML = "";
+    analysisSummary.textContent = "";
+    analysisSection.hidden = true;
+    configSection.hidden = true;
+  }
+
+  clearResults(state);
+  convertBtn.disabled = true;
+
   if (ffmpegReady) {
     cleanupTempFiles().catch((error) => {
       console.warn("清理临时文件时出错", error);
     });
   }
-  analysisBody.innerHTML = "";
-  analysisSummary.textContent = "";
-  analysisSection.hidden = true;
-  configSection.hidden = true;
-  convertBtn.disabled = true;
-  clearResults(state);
+
   updateFileInfo();
-  updateAnalyzeAndClearState();
-  if (state.selectedFiles.length === 0) {
-    if (rejectedCount > 0) {
-      const expectedLabel = currentMode === MODES.AUDIO ? "音频" : "视频";
-      setStatus(`已忽略 ${rejectedCount} 个非${expectedLabel}文件`);
-    } else {
-      setStatus(state.mediaEntries.length ? "已加载分析结果，可直接转换" : "等待操作");
-    }
-    return;
-  }
+  updateClearButtonState();
+  updateSortIndicators();
+
   if (rejectedCount > 0) {
     const expectedLabel = currentMode === MODES.AUDIO ? "音频" : "视频";
-    setStatus(`已忽略 ${rejectedCount} 个非${expectedLabel}文件，其他文件可继续分析`);
+    setStatus(`已忽略 ${rejectedCount} 个非${expectedLabel}文件，正在分析可用文件`);
   } else {
-    setStatus("准备就绪，点击分析文件以继续");
+    setStatus(hasExistingEntries ? "正在准备分析新增文件..." : "正在准备分析文件...");
   }
+
+  analyzeSelectedFiles({ append: hasExistingEntries });
 };
 
 const gatherMediaEntries = async (files, mode) => {
   const entries = [];
+  const uploadTracker = createUploadTracker();
   for (const file of files) {
     const label = file.webkitRelativePath || file.name;
-    await collectFromEntry(file, label, entries, mode);
+    const baseTimestamp = ensureTimestamp(getFileTimestamp(file));
+    await collectFromEntry(file, label, entries, mode, baseTimestamp, uploadTracker);
   }
   return entries;
 };
 
-const collectFromEntry = async (file, label, entries, mode) => {
+const collectFromEntry = async (
+  file,
+  label,
+  entries,
+  mode,
+  baseTimestamp,
+  uploadTracker,
+) => {
   if (!file) return;
   if (isZipFile(file.name)) {
     appendLog(`开始解压缩文件：${label}`);
@@ -781,16 +1251,34 @@ const collectFromEntry = async (file, label, entries, mode) => {
       const data = zipEntries[entryName];
       const fullLabel = joinLabel(label, entryName);
       if (isZipFile(entryName)) {
-        const nestedFile = new File([data], entryName, { type: "application/zip" });
-        await collectFromEntry(nestedFile, fullLabel, entries, mode);
+        const nestedFile = new File([data], entryName, {
+          type: "application/zip",
+          lastModified: ensureTimestamp(baseTimestamp),
+        });
+        await collectFromEntry(
+          nestedFile,
+          fullLabel,
+          entries,
+          mode,
+          baseTimestamp,
+          uploadTracker,
+        );
       } else {
-        const virtualFile = new File([data], entryName);
+        const virtualFile = new File([data], entryName, {
+          lastModified: ensureTimestamp(baseTimestamp),
+        });
         if (shouldIncludeFileForMode(virtualFile, mode)) {
+          const originalIndex = entries.length;
+          const uploadedAt = uploadTracker?.next?.() ?? Date.now();
           entries.push({
+            id: entryIdCounter += 1,
             file: virtualFile,
             displayName: fullLabel,
             ext: getExtension(entryName),
             type: mode === MODES.VIDEO ? "video" : "audio",
+            uploadedAt,
+            createdAt: ensureTimestamp(baseTimestamp),
+            originalIndex,
           });
         } else if (isVideoFile(virtualFile) || isAudioFile(virtualFile)) {
           const category = mode === MODES.VIDEO ? "视频" : "音频";
@@ -801,11 +1289,17 @@ const collectFromEntry = async (file, label, entries, mode) => {
       }
     }
   } else if (shouldIncludeFileForMode(file, mode)) {
+    const originalIndex = entries.length;
+    const uploadedAt = uploadTracker?.next?.() ?? Date.now();
     entries.push({
+      id: entryIdCounter += 1,
       file,
       displayName: label,
       ext: getExtension(file.name || file.webkitRelativePath || ""),
       type: mode === MODES.VIDEO ? "video" : "audio",
+      uploadedAt,
+      createdAt: ensureTimestamp(baseTimestamp),
+      originalIndex,
     });
   } else {
     const category = mode === MODES.VIDEO ? "视频" : "音频";
@@ -822,6 +1316,52 @@ const parseProbeLog = (log = "") => {
   const videoMatches = [...log.matchAll(/Video:\s*([^,\s]+)/gi)].map((m) => m[1].toLowerCase());
   const resolutionMatch = log.match(/Video:[^\n]*?,\s*(\d{2,5})x(\d{2,5})/i);
   const frameRateMatch = log.match(/\s([\d.]+)\s*fps/);
+  const durationMatch = log.match(/Duration:\s*(\d+):(\d+):(\d+(?:\.\d+)?)/i);
+  const bitrateMatch = log.match(/bitrate:\s*([\d.]+)\s*kb\/?s/i);
+
+  let durationSeconds = null;
+  if (durationMatch) {
+    const hours = Number(durationMatch[1]) || 0;
+    const minutes = Number(durationMatch[2]) || 0;
+    const seconds = Number(durationMatch[3]) || 0;
+    durationSeconds = hours * 3600 + minutes * 60 + seconds;
+  }
+
+  const bitrateBps = bitrateMatch ? Number(bitrateMatch[1]) * 1000 : null;
+
+  const metadata = {};
+  const lines = log.split(/\r?\n/);
+  let inMetadata = false;
+  for (const rawLine of lines) {
+    const line = rawLine || "";
+    if (/^\s*Metadata:/i.test(line)) {
+      inMetadata = true;
+      continue;
+    }
+    if (!inMetadata) {
+      continue;
+    }
+    if (/^\s*(?:Stream\s+#|Input\s+#|Output\s+#|Duration:|frame=|Press\s+\[q\])/i.test(line)) {
+      inMetadata = false;
+      continue;
+    }
+    if (!line.trim()) {
+      continue;
+    }
+    const metaMatch = line.match(/^\s*([^:]+?)\s*:\s*(.+)$/);
+    if (metaMatch) {
+      const key = metaMatch[1].trim().toLowerCase().replace(/\s+/g, "_");
+      const value = metaMatch[2].trim();
+      if (key && value && typeof metadata[key] === "undefined") {
+        metadata[key] = value;
+      }
+      continue;
+    }
+    if (!/^\s/.test(line)) {
+      inMetadata = false;
+    }
+  }
+
   return {
     audioCodec: audioMatches.length ? audioMatches[0] : null,
     videoCodec: videoMatches.length ? videoMatches[0] : null,
@@ -830,6 +1370,9 @@ const parseProbeLog = (log = "") => {
     width: resolutionMatch ? Number(resolutionMatch[1]) : null,
     height: resolutionMatch ? Number(resolutionMatch[2]) : null,
     frameRate: frameRateMatch ? Number(frameRateMatch[1]) : null,
+    duration: durationSeconds,
+    bitrate: Number.isFinite(bitrateBps) && bitrateBps > 0 ? bitrateBps : null,
+    metadata,
   };
 };
 
@@ -864,64 +1407,85 @@ const analyzeEntry = async (entry, index) => {
     width: info.width,
     height: info.height,
     frameRate: info.frameRate,
+    duration: info.duration,
+    bitrate: info.bitrate,
+    metadata: info.metadata || {},
   };
 };
 
-const analyzeSelectedFiles = async () => {
-  if (!state.selectedFiles.length) return;
-  analyzeBtn.disabled = true;
+const analyzeSelectedFiles = async ({ append = false } = {}) => {
+  if (!state.selectedFiles.length || isAnalyzing) return;
+  isAnalyzing = true;
   convertBtn.disabled = true;
   clearLog();
-  clearResults(state);
   resetProgress();
-  setStatus("正在初始化...");
+  setStatus(append ? "正在初始化新增文件..." : "正在初始化...");
+  if (fileInput) {
+    fileInput.disabled = true;
+  }
 
   try {
     await loadFFmpeg();
     await cleanupTempFiles();
     setStatus("正在扫描文件...");
-    const entries = await gatherMediaEntries(state.selectedFiles, currentMode);
-    if (!entries.length) {
-      setStatus(`未找到可用的${currentMode === MODES.VIDEO ? "视频" : "音频"}文件`);
-      analysisSection.hidden = true;
-      configSection.hidden = true;
+    const newEntries = await gatherMediaEntries(state.selectedFiles, currentMode);
+    if (!newEntries.length) {
+      const label = currentMode === MODES.VIDEO ? "视频" : "音频";
+      setStatus(append ? `未找到新的${label}文件` : `未找到可用的${label}文件`);
       state.selectedFiles = [];
       updateFileInfo();
-      updateAnalyzeAndClearState();
+      updateClearButtonState();
       updateFileInputForMode({ resetValue: true });
+      if (!append && !state.mediaEntries.length) {
+        analysisBody.innerHTML = "";
+        analysisSummary.textContent = "";
+        analysisSection.hidden = true;
+        configSection.hidden = true;
+        state.config = null;
+      } else if (state.mediaEntries.length) {
+        convertBtn.disabled = false;
+      }
       return;
     }
 
-    state.mediaEntries = entries;
-    state.hasVideoEntries = entries.some((entry) => entry.type === "video");
-    state.hasAudioEntries = entries.some((entry) => entry.type === "audio");
+    const existingCount = append ? state.mediaEntries.length : 0;
+    newEntries.forEach((entry, index) => {
+      entry.originalIndex = existingCount + index;
+    });
+
+    ensureUniqueDisplayNames(append ? state.mediaEntries : [], newEntries);
 
     setStatus("正在分析编码信息...");
-    for (let i = 0; i < entries.length; i += 1) {
-      setStatus(`分析文件 ${i + 1}/${entries.length}：${shortenLabel(entries[i].displayName)}`);
-      await analyzeEntry(entries[i], i);
-      updateProgress(((i + 1) / entries.length) * 100 * 0.6);
+    for (let i = 0; i < newEntries.length; i += 1) {
+      setStatus(`分析文件 ${i + 1}/${newEntries.length}：${shortenLabel(newEntries[i].displayName)}`);
+      await analyzeEntry(newEntries[i], existingCount + i);
+      updateProgress(((i + 1) / newEntries.length) * 100 * 0.6);
     }
 
-    const videoEntries = entries.filter((entry) => entry.type === "video");
-    state.videoEntriesWithAudio = videoEntries.some((entry) => entry.analysis?.hasAudio);
+    state.mediaEntries = append ? state.mediaEntries.concat(newEntries) : newEntries;
+    recalculateEntryFlags();
 
     state.selectedFiles = [];
     updateFileInfo();
-    updateAnalyzeAndClearState();
+    updateClearButtonState();
     updateFileInputForMode({ resetValue: true });
 
-    buildAnalysisTable(entries);
-    prepareConfiguration({ restoreConfig: false });
+    buildAnalysisTable(state.mediaEntries);
+    const shouldRestoreConfig = append && Boolean(state.config);
+    prepareConfiguration({ restoreConfig: shouldRestoreConfig });
     state.config = captureConfigState();
-    setStatus("分析完成，可调整转换设置");
+    setStatus(append ? "新增文件分析完成" : "分析完成，可调整转换设置");
     convertBtn.disabled = false;
   } catch (error) {
     console.error(error);
     appendLog(`错误：${error.message || error}`);
     setStatus("分析失败，请重试");
   } finally {
-    analyzeBtn.disabled = state.selectedFiles.length === 0;
+    isAnalyzing = false;
+    if (fileInput) {
+      fileInput.disabled = false;
+    }
+    updateSortIndicators();
   }
 };
 
@@ -930,6 +1494,7 @@ const buildAnalysisTable = (entries) => {
   if (!entries.length) {
     analysisSummary.textContent = "";
     analysisSection.hidden = true;
+    updateSortIndicators();
     return;
   }
 
@@ -939,7 +1504,9 @@ const buildAnalysisTable = (entries) => {
   let videoCount = 0;
   let totalSize = 0;
 
-  for (const entry of entries) {
+  const sortedEntries = sortEntriesForDisplay(entries);
+
+  for (const entry of sortedEntries) {
     const tr = document.createElement("tr");
     const labelCell = document.createElement("td");
     labelCell.textContent = entry.displayName;
@@ -956,6 +1523,16 @@ const buildAnalysisTable = (entries) => {
     sizeCell.classList.add("analysis-size");
     tr.appendChild(sizeCell);
     totalSize += size;
+
+    const uploadTimeCell = document.createElement("td");
+    uploadTimeCell.classList.add("analysis-time");
+    uploadTimeCell.textContent = formatDateTime(entry.uploadedAt);
+    tr.appendChild(uploadTimeCell);
+
+    const createdTimeCell = document.createElement("td");
+    createdTimeCell.classList.add("analysis-time");
+    createdTimeCell.textContent = formatDateTime(entry.createdAt);
+    tr.appendChild(createdTimeCell);
 
     const containerCell = document.createElement("td");
     containerCell.textContent = entry.analysis?.container ? `.${entry.analysis.container}` : "未知";
@@ -989,13 +1566,38 @@ const buildAnalysisTable = (entries) => {
     tr.appendChild(frameRateCell);
 
     const videoCodecCell = document.createElement("td");
-    videoCodecCell.classList.add("column-video-only");
     videoCodecCell.textContent = entry.analysis?.videoCodec || (entry.type === "video" ? "未检测到" : "-");
     tr.appendChild(videoCodecCell);
 
     const audioCodecCell = document.createElement("td");
-    audioCodecCell.textContent = entry.analysis?.audioCodec || (entry.analysis?.hasAudio ? "未知" : "-");
+    if (entry.analysis?.audioCodec) {
+      audioCodecCell.textContent = entry.analysis.audioCodec;
+    } else if (entry.analysis?.hasAudio) {
+      audioCodecCell.textContent = "未知";
+    } else {
+      audioCodecCell.textContent = "未检测到";
+    }
     tr.appendChild(audioCodecCell);
+
+    const actionsCell = document.createElement("td");
+    actionsCell.classList.add("analysis-actions");
+    const detailButton = document.createElement("button");
+    detailButton.type = "button";
+    detailButton.classList.add("detail-button", "analysis-action-button");
+    detailButton.textContent = "详情";
+    detailButton.dataset.entryId = String(entry.id);
+    detailButton.setAttribute("aria-label", `查看 ${entry.displayName} 的详细信息`);
+    actionsCell.appendChild(detailButton);
+
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.classList.add("delete-button", "analysis-action-button");
+    deleteButton.textContent = "删除";
+    deleteButton.dataset.entryId = String(entry.id);
+    deleteButton.setAttribute("aria-label", `从列表移除 ${entry.displayName}`);
+    actionsCell.appendChild(deleteButton);
+
+    tr.appendChild(actionsCell);
 
     analysisBody.appendChild(tr);
 
@@ -1010,6 +1612,177 @@ const buildAnalysisTable = (entries) => {
   analysisSummary.textContent = summaryParts.length ? `共检测到 ${summaryParts.join("、")}` : "";
 
   analysisSection.hidden = false;
+  updateSortIndicators();
+};
+
+const removeEntryById = (entryId) => {
+  if (!entryId) return;
+  if (isAnalyzing) {
+    setStatus("正在分析文件，请稍候再删除");
+    return;
+  }
+  const index = state.mediaEntries.findIndex((entry) => String(entry.id) === String(entryId));
+  if (index === -1) return;
+  const [removed] = state.mediaEntries.splice(index, 1);
+  if (removed?.inputName && trackedTempFiles.has(removed.inputName)) {
+    ffmpeg.deleteFile?.(removed.inputName).catch(() => {});
+    releaseTempFile(removed.inputName);
+  }
+  state.mediaEntries.forEach((entry, idx) => {
+    if (entry) {
+      entry.originalIndex = idx;
+    }
+  });
+  recalculateEntryFlags();
+  clearResults(state);
+
+  if (state.mediaEntries.length) {
+    buildAnalysisTable(state.mediaEntries);
+    prepareConfiguration({ restoreConfig: Boolean(state.config) });
+    state.config = captureConfigState();
+    convertBtn.disabled = false;
+    const removedLabel = shortenLabel(removed?.displayName || "选定文件");
+    setStatus(`已移除 ${removedLabel}`);
+  } else {
+    analysisBody.innerHTML = "";
+    analysisSummary.textContent = "";
+    analysisSection.hidden = true;
+    configSection.hidden = true;
+    state.config = null;
+    convertBtn.disabled = true;
+    setStatus("已移除所有文件，等待操作");
+  }
+
+  updateFileInfo();
+  updateClearButtonState();
+  updateSortIndicators();
+};
+
+const closeDetailModal = () => {
+  if (!detailModal) return;
+  detailModal.classList.remove("is-visible");
+  detailModal.setAttribute("hidden", "");
+  if (detailModalContent) {
+    detailModalContent.innerHTML = "";
+  }
+  if (lastFocusedElement && typeof lastFocusedElement.focus === "function") {
+    try {
+      lastFocusedElement.focus();
+    } catch (error) {
+      // ignore focus restoration errors
+    }
+  }
+  lastFocusedElement = null;
+};
+
+const openDetailModal = (entry) => {
+  if (!entry || !detailModal || !detailModalContent || !detailModalDialog) return;
+  lastFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  detailModalContent.innerHTML = "";
+  detailModal.removeAttribute("hidden");
+  detailModal.classList.add("is-visible");
+
+  if (detailModalTitle) {
+    detailModalTitle.textContent = entry.displayName || "文件详情";
+  }
+
+  const detailList = document.createElement("dl");
+  detailList.classList.add("detail-list");
+
+  const appendRow = (label, value, { skipIfEmpty = false } = {}) => {
+    const normalized = value !== undefined && value !== null ? String(value) : "";
+    if (skipIfEmpty && !normalized) {
+      return;
+    }
+    const dt = document.createElement("dt");
+    dt.textContent = label;
+    const dd = document.createElement("dd");
+    dd.textContent = normalized || "未知";
+    detailList.appendChild(dt);
+    detailList.appendChild(dd);
+  };
+
+  appendRow("来源路径", entry.displayName || entry.file?.name || "");
+  if (entry.file?.name && entry.file.name !== entry.displayName) {
+    appendRow("原始文件名", entry.file.name, { skipIfEmpty: true });
+  }
+  appendRow("媒体类型", entry.type === "video" ? "视频" : "音频");
+  appendRow("上传时间", formatDateTime(entry.uploadedAt));
+  appendRow("文件创建时间", formatDateTime(entry.createdAt));
+  appendRow("文件大小", formatBytes(entry.file?.size ?? 0));
+  appendRow("MIME 类型", entry.file?.type || "", { skipIfEmpty: true });
+  appendRow(
+    "容器格式",
+    entry.analysis?.container ? `.${entry.analysis.container}` : entry.ext ? `.${entry.ext}` : ""
+  );
+
+  const metadata = entry.analysis?.metadata || {};
+  const pickMetadataValue = (...keys) => {
+    for (const key of keys) {
+      const value = normalizeMetadataValue(metadata[key]);
+      if (value) {
+        return value;
+      }
+    }
+    return "";
+  };
+  if (metadata.creation_time) {
+    appendRow("媒体创建时间", formatMetadataDate(metadata.creation_time), { skipIfEmpty: true });
+  }
+  appendRow("媒体时长", formatDuration(entry.analysis?.duration));
+  appendRow("整体码率", formatBitrate(entry.analysis?.bitrate));
+  appendRow("专辑", pickMetadataValue("album", "album_artist", "albumartist", "alb"), {
+    skipIfEmpty: true,
+  });
+  appendRow(
+    "艺术家",
+    pickMetadataValue(
+      "artist",
+      "performer",
+      "author",
+      "album_artist",
+      "albumartist",
+      "composer",
+    ),
+    { skipIfEmpty: true },
+  );
+
+  if (entry.type === "video" || entry.analysis?.hasVideo) {
+    const resolution =
+      entry.analysis?.width && entry.analysis?.height
+        ? `${entry.analysis.width}×${entry.analysis.height}`
+        : "";
+    appendRow("视频分辨率", resolution);
+    appendRow("视频帧率", entry.analysis?.frameRate ? formatFrameRate(entry.analysis.frameRate) : "");
+  }
+
+  const videoCodecValue =
+    entry.type === "video"
+      ? entry.analysis?.videoCodec || "未检测到"
+      : entry.analysis?.hasVideo
+      ? entry.analysis?.videoCodec || "未知"
+      : "不适用";
+  appendRow("视频编码", videoCodecValue);
+
+  const audioCodecValue = entry.analysis?.audioCodec
+    ? entry.analysis.audioCodec
+    : entry.analysis?.hasAudio
+    ? "未知"
+    : "未检测到";
+  appendRow("音频编码", audioCodecValue);
+
+  appendRow("包含音频轨道", entry.analysis?.hasAudio ? "是" : "否");
+  appendRow("包含视频轨道", entry.analysis?.hasVideo ? "是" : "否");
+
+  detailModalContent.appendChild(detailList);
+
+  setTimeout(() => {
+    try {
+      detailModalDialog.focus({ preventScroll: true });
+    } catch (error) {
+      // ignore focus errors
+    }
+  }, 0);
 };
 
 const populateSelect = (select, options, { includeCopyForAny = false } = {}) => {
@@ -1554,7 +2327,7 @@ const renderResults = (modeState = state) => {
     if (!modeState || !modeState.mediaEntries.length) {
       configSection.hidden = true;
     }
-    updateAnalyzeAndClearState();
+    updateClearButtonState();
     return;
   }
 
@@ -1591,7 +2364,7 @@ const renderResults = (modeState = state) => {
   };
 
   resultSection.hidden = false;
-  updateAnalyzeAndClearState();
+  updateClearButtonState();
 };
 
 const switchMode = (mode) => {
@@ -1599,6 +2372,7 @@ const switchMode = (mode) => {
   if (!configSection.hidden && state.mediaEntries.length) {
     state.config = captureConfigState();
   }
+  closeDetailModal();
   currentMode = mode;
   state = modeStates[currentMode];
   updateModeTabs();
@@ -1619,16 +2393,18 @@ const switchMode = (mode) => {
     convertBtn.disabled = true;
     if (conversionProgress.total === 0) {
       const statusMessage = state.selectedFiles.length
-        ? "准备就绪，点击分析文件以继续"
+        ? "正在准备分析，请稍候"
         : "等待操作";
       setStatus(statusMessage);
     }
   }
   renderResults(state);
-  updateAnalyzeAndClearState();
+  updateClearButtonState();
+  updateSortIndicators();
 };
 
 const clearAllUploads = async () => {
+  closeDetailModal();
   const activeMode = currentMode;
   resetModeState(MODES.AUDIO);
   resetModeState(MODES.VIDEO);
@@ -1643,7 +2419,8 @@ const clearAllUploads = async () => {
   convertBtn.disabled = true;
   renderResults(state);
   updateFileInfo();
-  updateAnalyzeAndClearState();
+  updateClearButtonState();
+  updateSortIndicators();
   setStatus("等待操作");
   if (ffmpegReady) {
     try {
@@ -1685,6 +2462,56 @@ ffmpeg.on("progress", ({ progress }) => {
     }
   }
   setStatus(message);
+});
+
+if (analysisBody) {
+  analysisBody.addEventListener("click", (event) => {
+    if (!(event.target instanceof Element)) return;
+
+    const deleteTarget = event.target.closest(".delete-button");
+    if (deleteTarget) {
+      const entryId = deleteTarget.dataset.entryId;
+      if (entryId) {
+        removeEntryById(entryId);
+      }
+      return;
+    }
+
+    const detailTarget = event.target.closest(".detail-button");
+    if (!detailTarget) return;
+    const entryId = detailTarget.dataset.entryId;
+    if (!entryId) return;
+    const entry = state.mediaEntries.find((item) => String(item.id) === entryId);
+    if (entry) {
+      openDetailModal(entry);
+    }
+  });
+}
+
+detailModalClose?.addEventListener("click", () => {
+  closeDetailModal();
+});
+
+detailModalBackdrop?.addEventListener("click", (event) => {
+  if (event.target === detailModalBackdrop) {
+    closeDetailModal();
+  }
+});
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && detailModal?.classList.contains("is-visible")) {
+    event.preventDefault();
+    closeDetailModal();
+  }
+});
+
+sortButtons.forEach((button) => {
+  button.addEventListener("click", () => {
+    const sortKey = button.dataset.sortKey;
+    if (sortKey) {
+      applySortForKey(sortKey);
+    }
+  });
 });
 
 presetSelect.addEventListener("change", () => {
@@ -1743,11 +2570,6 @@ clearBtn?.addEventListener("click", () => {
   clearAllUploads();
 });
 
-analyzeBtn.addEventListener("click", () => {
-  if (!state.selectedFiles.length) return;
-  analyzeSelectedFiles();
-});
-
 convertBtn.addEventListener("click", () => {
   if (!state.mediaEntries.length) return;
   convertEntries();
@@ -1756,6 +2578,7 @@ convertBtn.addEventListener("click", () => {
 registerFileInputListeners(fileInput);
 
 dropZone.addEventListener("dragover", (event) => {
+  if (isAnalyzing) return;
   event.preventDefault();
   dropZone.classList.add("dragover");
 });
@@ -1767,13 +2590,12 @@ dropZone.addEventListener("dragleave", () => {
 dropZone.addEventListener("drop", (event) => {
   event.preventDefault();
   dropZone.classList.remove("dragover");
+  if (isAnalyzing) {
+    setStatus("正在分析当前文件，请稍候再上传新文件");
+    return;
+  }
   const files = event.dataTransfer?.files;
   if (files && files.length) {
-    try {
-      fileInput.files = files;
-    } catch (error) {
-      // ignore inability to set files programmatically
-    }
     selectFiles(Array.from(files));
   }
 });
@@ -1788,7 +2610,8 @@ window.addEventListener("beforeunload", () => {
 updateModeTabs();
 updateFileInputForMode();
 updateFileInfo();
-updateAnalyzeAndClearState();
+updateClearButtonState();
+updateSortIndicators();
 renderResults(state);
 
 analysisSection.hidden = true;

--- a/styles.css
+++ b/styles.css
@@ -524,6 +524,101 @@ table {
   white-space: nowrap;
 }
 
+
+.analysis-time {
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-secondary);
+}
+
+.analysis-actions {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: nowrap;
+}
+
+.sort-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0;
+  margin: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  line-height: inherit;
+}
+
+.sort-button:focus-visible {
+  outline: none;
+  box-shadow: inset 0 -2px 0 0 currentColor;
+}
+
+.sort-button:hover {
+  color: var(--accent-end);
+}
+
+.sort-button::after {
+  content: "";
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 0.2rem;
+  border-left: 0.28em solid transparent;
+  border-right: 0.28em solid transparent;
+  opacity: 0;
+  transition: opacity 0.15s ease, transform 0.15s ease;
+}
+
+.sort-button[data-sort-state="asc"]::after {
+  border-bottom: 0.34em solid currentColor;
+  border-top: 0;
+  transform: translateY(-0.1em);
+  opacity: 0.85;
+}
+
+.sort-button[data-sort-state="desc"]::after {
+  border-top: 0.34em solid currentColor;
+  border-bottom: 0;
+  transform: translateY(0.1em);
+  opacity: 0.85;
+}
+
+.analysis-action-button {
+  border: 1px solid var(--border-color);
+  background: transparent;
+  padding: 0.3rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.analysis-action-button:hover,
+.analysis-action-button:focus-visible {
+  border-color: var(--accent-end);
+  color: var(--accent-end);
+  background: rgba(59, 130, 246, 0.08);
+  outline: none;
+}
+
+.delete-button {
+  color: #dc2626;
+  border-color: rgba(220, 38, 38, 0.4);
+}
+
+.delete-button:hover,
+.delete-button:focus-visible {
+  color: #dc2626;
+  border-color: rgba(220, 38, 38, 0.65);
+  background: rgba(220, 38, 38, 0.1);
+}
+
 thead {
   background: var(--surface-muted-bg);
 }
@@ -537,6 +632,95 @@ td {
 
 tbody tr:hover {
   background: rgba(148, 163, 184, 0.12);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal.is-visible {
+  display: flex;
+}
+
+.modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.modal-dialog {
+  position: relative;
+  background: var(--surface-bg);
+  border-radius: 16px;
+  padding: 1.5rem;
+  width: min(560px, calc(100% - 2.5rem));
+  max-height: calc(100% - 4rem);
+  box-shadow: 0 24px 64px rgba(15, 23, 42, 0.35);
+  border: 1px solid var(--border-color);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.modal-header h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.modal-close {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0.25rem;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.modal-close:hover,
+.modal-close:focus-visible {
+  color: var(--accent-end);
+  background: rgba(59, 130, 246, 0.1);
+  outline: none;
+}
+
+.modal-content {
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.detail-list {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  column-gap: 1.25rem;
+  row-gap: 0.5rem;
+  margin: 0;
+}
+
+.detail-list dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.detail-list dd {
+  margin: 0;
+  color: var(--text-primary);
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
 }
 
 .config form {


### PR DESCRIPTION
## Summary
- relax the video input accept restriction on iOS so MKV 等容器可以正常选中，并在分析前保留已有条目
- 支持连续追加上传，自动为重名文件追加编号并在文件列表加入删除按钮
- 将上传时间与创建时间拆成独立列，微调排序按钮与操作按钮样式以去除蓝色圆圈

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d53db3bf24833283bfad66fe1ce558