### PR TITLE
Adjust sort buttons appearance

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -539,7 +539,7 @@ table {
   white-space: nowrap;
 }
 
-.sort-button {
+button.sort-button {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
@@ -547,22 +547,24 @@ table {
   margin: 0;
   border: none;
   background: transparent;
+  border-radius: 0;
+  box-shadow: none;
   font: inherit;
-  color: inherit;
+  color: #000;
   cursor: pointer;
   line-height: inherit;
 }
 
-.sort-button:focus-visible {
+button.sort-button:focus-visible {
   outline: none;
   box-shadow: inset 0 -2px 0 0 currentColor;
 }
 
-.sort-button:hover {
-  color: var(--accent-end);
+button.sort-button:hover {
+  color: #000;
 }
 
-.sort-button::after {
+button.sort-button::after {
   content: "";
   display: inline-block;
   width: 0;
@@ -574,14 +576,14 @@ table {
   transition: opacity 0.15s ease, transform 0.15s ease;
 }
 
-.sort-button[data-sort-state="asc"]::after {
+button.sort-button[data-sort-state="asc"]::after {
   border-bottom: 0.34em solid currentColor;
   border-top: 0;
   transform: translateY(-0.1em);
   opacity: 0.85;
 }
 
-.sort-button[data-sort-state="desc"]::after {
+button.sort-button[data-sort-state="desc"]::after {
   border-top: 0.34em solid currentColor;
   border-bottom: 0;
   transform: translateY(0.1em);


### PR DESCRIPTION
## Summary
- ensure table sort buttons are rendered as plain text without gradient backgrounds
- force the sort button label color to black while preserving arrow indicators

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5e2fa0d58833285cc28f592f51d3b