### PR TITLE
Refine sort header focus behavior

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -539,49 +539,57 @@ table {
   white-space: nowrap;
 }
 
-.sort-button {
-  display: inline-flex;
+button.sort-button {
+  display: inline-grid;
+  grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: 0.25rem;
   padding: 0;
   margin: 0;
   border: none;
   background: transparent;
+  border-radius: 0;
+  box-shadow: none;
   font: inherit;
-  color: inherit;
+  color: #000;
   cursor: pointer;
-  line-height: inherit;
+  line-height: 1.3;
+  text-align: left;
+  white-space: normal;
+  word-break: break-word;
+  max-height: calc(1.3em * 2);
+  overflow: hidden;
 }
 
-.sort-button:focus-visible {
+button.sort-button:focus-visible {
   outline: none;
-  box-shadow: inset 0 -2px 0 0 currentColor;
 }
 
-.sort-button:hover {
-  color: var(--accent-end);
+button.sort-button:hover {
+  color: #000;
 }
 
-.sort-button::after {
+button.sort-button::after {
   content: "";
-  display: inline-block;
+  justify-self: center;
+  align-self: center;
   width: 0;
   height: 0;
-  margin-left: 0.2rem;
   border-left: 0.28em solid transparent;
   border-right: 0.28em solid transparent;
   opacity: 0;
   transition: opacity 0.15s ease, transform 0.15s ease;
+  grid-column: 2;
 }
 
-.sort-button[data-sort-state="asc"]::after {
+button.sort-button[data-sort-state="asc"]::after {
   border-bottom: 0.34em solid currentColor;
   border-top: 0;
   transform: translateY(-0.1em);
   opacity: 0.85;
 }
 
-.sort-button[data-sort-state="desc"]::after {
+button.sort-button[data-sort-state="desc"]::after {
   border-top: 0.34em solid currentColor;
   border-bottom: 0;
   transform: translateY(0.1em);


### PR DESCRIPTION
## Summary
- remove the focus halo from the uploaded files sort header buttons
- allow sort header labels to wrap to at most two lines while keeping the caret aligned

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5e2fa0d58833285cc28f592f51d3b