### PR TITLE
Adjust sort header focus and layout

### DIFF
--- a/converter.html
+++ b/converter.html
@@ -60,34 +60,54 @@
             <thead>
               <tr>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="displayName">文件</button>
+                  <button type="button" class="sort-button" data-sort-key="displayName">
+                    <span class="sort-button-label">文件</span>
+                  </button>
                 </th>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="type">类型</button>
+                  <button type="button" class="sort-button" data-sort-key="type">
+                    <span class="sort-button-label">类型</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-size">
-                  <button type="button" class="sort-button" data-sort-key="size">大小</button>
+                  <button type="button" class="sort-button" data-sort-key="size">
+                    <span class="sort-button-label">大小</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-time">
-                  <button type="button" class="sort-button" data-sort-key="uploadedAt">上传时间</button>
+                  <button type="button" class="sort-button" data-sort-key="uploadedAt">
+                    <span class="sort-button-label">上传时间</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-time">
-                  <button type="button" class="sort-button" data-sort-key="createdAt">创建时间</button>
+                  <button type="button" class="sort-button" data-sort-key="createdAt">
+                    <span class="sort-button-label">创建时间</span>
+                  </button>
                 </th>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="container">容器</button>
+                  <button type="button" class="sort-button" data-sort-key="container">
+                    <span class="sort-button-label">容器</span>
+                  </button>
                 </th>
                 <th scope="col" class="column-video-only">
-                  <button type="button" class="sort-button" data-sort-key="resolution">分辨率</button>
+                  <button type="button" class="sort-button" data-sort-key="resolution">
+                    <span class="sort-button-label">分辨率</span>
+                  </button>
                 </th>
                 <th scope="col" class="column-video-only">
-                  <button type="button" class="sort-button" data-sort-key="frameRate">帧率</button>
+                  <button type="button" class="sort-button" data-sort-key="frameRate">
+                    <span class="sort-button-label">帧率</span>
+                  </button>
                 </th>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="videoCodec">视频编码</button>
+                  <button type="button" class="sort-button" data-sort-key="videoCodec">
+                    <span class="sort-button-label">视频编码</span>
+                  </button>
                 </th>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="audioCodec">音频编码</button>
+                  <button type="button" class="sort-button" data-sort-key="audioCodec">
+                    <span class="sort-button-label">音频编码</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-actions">操作</th>
               </tr>

--- a/styles.css
+++ b/styles.css
@@ -553,6 +553,13 @@ button.sort-button {
   color: #000;
   cursor: pointer;
   line-height: inherit;
+  text-align: left;
+  white-space: normal;
+}
+
+button.sort-button:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 button.sort-button:focus-visible {
@@ -562,6 +569,17 @@ button.sort-button:focus-visible {
 
 button.sort-button:hover {
   color: #000;
+}
+
+.sort-button-label {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.2;
+  max-height: calc(1em * 1.2 * 2);
+  word-break: break-word;
 }
 
 button.sort-button::after {


### PR DESCRIPTION
## Summary
- wrap table header sort buttons with span labels to enable controlled line clamping
- update sort button styling to remove pointer focus halo while preserving keyboard focus treatment
- clamp header labels to two lines with ellipsis to keep attribute titles compact

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d5ee5152988332aa4664f160fa9592