### PR TITLE
Improve sort header behaviour on iOS Safari

### DIFF
--- a/converter.html
+++ b/converter.html
@@ -60,34 +60,54 @@
             <thead>
               <tr>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="displayName">文件</button>
+                  <button type="button" class="sort-button" data-sort-key="displayName">
+                    <span class="sort-button-label">文件</span>
+                  </button>
                 </th>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="type">类型</button>
+                  <button type="button" class="sort-button" data-sort-key="type">
+                    <span class="sort-button-label">类型</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-size">
-                  <button type="button" class="sort-button" data-sort-key="size">大小</button>
+                  <button type="button" class="sort-button" data-sort-key="size">
+                    <span class="sort-button-label">大小</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-time">
-                  <button type="button" class="sort-button" data-sort-key="uploadedAt">上传时间</button>
+                  <button type="button" class="sort-button" data-sort-key="uploadedAt">
+                    <span class="sort-button-label">上传时间</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-time">
-                  <button type="button" class="sort-button" data-sort-key="createdAt">创建时间</button>
+                  <button type="button" class="sort-button" data-sort-key="createdAt">
+                    <span class="sort-button-label">创建时间</span>
+                  </button>
                 </th>
                 <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="container">容器</button>
+                  <button type="button" class="sort-button" data-sort-key="container">
+                    <span class="sort-button-label">容器</span>
+                  </button>
                 </th>
                 <th scope="col" class="column-video-only">
-                  <button type="button" class="sort-button" data-sort-key="resolution">分辨率</button>
+                  <button type="button" class="sort-button" data-sort-key="resolution">
+                    <span class="sort-button-label">分辨率</span>
+                  </button>
                 </th>
                 <th scope="col" class="column-video-only">
-                  <button type="button" class="sort-button" data-sort-key="frameRate">帧率</button>
+                  <button type="button" class="sort-button" data-sort-key="frameRate">
+                    <span class="sort-button-label">帧率</span>
+                  </button>
                 </th>
-                <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="videoCodec">视频编码</button>
+                <th scope="col" class="analysis-codec">
+                  <button type="button" class="sort-button" data-sort-key="videoCodec">
+                    <span class="sort-button-label">视频编码</span>
+                  </button>
                 </th>
-                <th scope="col">
-                  <button type="button" class="sort-button" data-sort-key="audioCodec">音频编码</button>
+                <th scope="col" class="analysis-codec">
+                  <button type="button" class="sort-button" data-sort-key="audioCodec">
+                    <span class="sort-button-label">音频编码</span>
+                  </button>
                 </th>
                 <th scope="col" class="analysis-actions">操作</th>
               </tr>

--- a/styles.css
+++ b/styles.css
@@ -531,7 +531,12 @@ table {
   color: var(--text-secondary);
 }
 
-.analysis-actions {
+th.analysis-actions {
+  text-align: center;
+  white-space: nowrap;
+}
+
+td.analysis-actions {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -539,8 +544,12 @@ table {
   white-space: nowrap;
 }
 
+.analysis-codec {
+  min-width: 7ch;
+}
+
 button.sort-button {
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: 0.25rem;
   padding: 0;
@@ -550,18 +559,53 @@ button.sort-button {
   border-radius: 0;
   box-shadow: none;
   font: inherit;
-  color: #000;
+  color: var(--text-secondary);
   cursor: pointer;
   line-height: inherit;
+  text-align: left;
+  white-space: normal;
+  position: relative;
+  outline: none;
+  transition: color 0.2s ease;
+  -webkit-tap-highlight-color: transparent;
+  width: 100%;
+}
+
+button.sort-button:focus {
+  outline: none;
+  box-shadow: none;
 }
 
 button.sort-button:focus-visible {
   outline: none;
-  box-shadow: inset 0 -2px 0 0 currentColor;
+  box-shadow: none;
+  color: var(--text-primary);
 }
 
 button.sort-button:hover {
-  color: #000;
+  color: var(--text-primary);
+}
+
+button.sort-button:focus-visible .sort-button-label {
+  text-decoration: underline;
+  color: var(--text-primary);
+}
+
+.sort-button-label {
+  flex: 1 1 auto;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+  max-height: calc(1.25em * 2);
+  text-decoration: none;
+  text-decoration-thickness: 2px;
+  text-decoration-color: var(--accent-start);
+  text-underline-offset: 0.2em;
 }
 
 button.sort-button::after {


### PR DESCRIPTION
## Summary
- expand analysis table sort buttons to fill the header cell so labels wrap cleanly on iOS Safari
- add Safari tap highlight suppression and label flex behavior to eliminate the residual blue halo
- clamp header labels to two lines with explicit height and break settings for consistent codec titles

## Testing
- not run (project has no automated tests)

------
https://chatgpt.com/codex/tasks/task_e_68d5ee5152988332aa4664f160fa9592