### PR TITLE
Remove focus halo from analysis column headers

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -556,6 +556,8 @@ button.sort-button {
   margin: 0;
   border: none;
   background: transparent;
+  appearance: none;
+  -webkit-appearance: none;
   border-radius: 0;
   box-shadow: none;
   font: inherit;


### PR DESCRIPTION
## Summary
- disable the native focus appearance for sortable table headers
- keep the existing custom focus styles without the default blue halo

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63afba1c8833299b556726eb13264