### PR TITLE
Remove problematic Opus encoding options

### DIFF
--- a/converter.js
+++ b/converter.js
@@ -2374,14 +2374,6 @@ const applyAudioCodecSpecificArgs = (args, { audioCodec, container, audioQuality
     args.push("-application", "audio");
   }
 
-  if (!hasArgument(args, "-frame_duration")) {
-    args.push("-frame_duration", "60");
-  }
-
-  if (!hasArgument(args, "-af")) {
-    args.push("-af", "aresample=async=1:first_pts=0");
-  }
-
   if (container === "opus") {
     if (!hasArgument(args, "-f")) {
       args.push("-f", "opus");


### PR DESCRIPTION
## Summary
- stop adding Opus frame duration and resample filter options that were stalling conversions

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68f24b0523888332b0a984be294bb540